### PR TITLE
Correct RTS/CTS Toggle

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,6 +79,7 @@ async def make_znp_server(mocker):
     transports = []
     double_connect = False
 
+    mocker.patch("zigpy_znp.api.AFTER_CONNECT_DELAY", 0.001)
     mocker.patch("zigpy_znp.api.STARTUP_DELAY", 0.001)
     mocker.patch("zigpy_znp.uart.RTS_TOGGLE_DELAY", 0)
 

--- a/tests/test_uart.py
+++ b/tests/test_uart.py
@@ -286,8 +286,8 @@ async def test_connection_made(dummy_serial_conn, mocker):
 async def test_no_toggle_rts(dummy_serial_conn, mocker):
     device, serial = dummy_serial_conn
 
-    type(serial).dsrdtr = dsrdtr = mocker.PropertyMock()
-    type(serial).rtscts = rtscts = mocker.PropertyMock()
+    type(serial).dtr = dtr = mocker.PropertyMock()
+    type(serial).rts = rts = mocker.PropertyMock()
 
     znp = mocker.Mock()
 
@@ -295,8 +295,8 @@ async def test_no_toggle_rts(dummy_serial_conn, mocker):
         conf.SCHEMA_DEVICE({conf.CONF_DEVICE_PATH: device}), api=znp, toggle_rts=False
     )
 
-    assert dsrdtr.mock_calls == []
-    assert rtscts.mock_calls == []
+    assert dtr.mock_calls == []
+    assert rts.mock_calls == []
 
 
 @pytest.mark.timeout(1)
@@ -304,8 +304,8 @@ async def test_no_toggle_rts(dummy_serial_conn, mocker):
 async def test_toggle_rts(dummy_serial_conn, mocker):
     device, serial = dummy_serial_conn
 
-    type(serial).dsrdtr = dsrdtr = mocker.PropertyMock()
-    type(serial).rtscts = rtscts = mocker.PropertyMock()
+    type(serial).dtr = dtr = mocker.PropertyMock()
+    type(serial).rts = rts = mocker.PropertyMock()
 
     znp = mocker.Mock()
 
@@ -313,12 +313,12 @@ async def test_toggle_rts(dummy_serial_conn, mocker):
         conf.SCHEMA_DEVICE({conf.CONF_DEVICE_PATH: device}), api=znp, toggle_rts=True
     )
 
-    assert dsrdtr.mock_calls == [
+    assert dtr.mock_calls == [
         mocker.call(False),
         mocker.call(False),
         mocker.call(False),
     ]
-    assert rtscts.mock_calls == [
+    assert rts.mock_calls == [
         mocker.call(False),
         mocker.call(True),
         mocker.call(False),

--- a/zigpy_znp/api.py
+++ b/zigpy_znp/api.py
@@ -203,6 +203,8 @@ class ZNP:
                 # XXX: Z-Stack locks up if other radios try probing it first.
                 #      Writing the bootloader skip byte a bunch of times (at least 167)
                 #      appears to reset it.
+                LOGGER.debug("Waiting 1s before the skip bytes are sent")
+                await asyncio.sleep(1)
                 skip = bytes([c.ubl.BootloaderRunMode.FORCE_RUN])
                 self._uart._transport_write(skip * 256)
 

--- a/zigpy_znp/api.py
+++ b/zigpy_znp/api.py
@@ -203,8 +203,6 @@ class ZNP:
                 # XXX: Z-Stack locks up if other radios try probing it first.
                 #      Writing the bootloader skip byte a bunch of times (at least 167)
                 #      appears to reset it.
-                LOGGER.debug("Waiting 1s before the skip bytes are sent")
-                await asyncio.sleep(1)
                 skip = bytes([c.ubl.BootloaderRunMode.FORCE_RUN])
                 self._uart._transport_write(skip * 256)
 

--- a/zigpy_znp/api.py
+++ b/zigpy_znp/api.py
@@ -21,6 +21,7 @@ from zigpy_znp.exceptions import CommandNotRecognized, InvalidCommandResponse
 
 
 LOGGER = logging.getLogger(__name__)
+AFTER_CONNECT_DELAY = 1  # seconds
 STARTUP_DELAY = 1  # seconds
 
 
@@ -196,6 +197,9 @@ class ZNP:
 
         try:
             self._uart = await uart.connect(self._config[conf.CONF_DEVICE], self)
+
+            LOGGER.debug("Waiting %ss before sending anything", AFTER_CONNECT_DELAY)
+            await asyncio.sleep(AFTER_CONNECT_DELAY)
 
             if self._config[conf.CONF_ZNP_CONFIG][conf.CONF_SKIP_BOOTLOADER]:
                 LOGGER.debug("Sending bootloader skip byte")

--- a/zigpy_znp/uart.py
+++ b/zigpy_znp/uart.py
@@ -255,4 +255,7 @@ async def connect(config: conf.ConfigType, api, *, toggle_rts=True) -> ZnpMtProt
 
     LOGGER.debug("Connected to %s at %s baud", port, baudrate)
 
+    LOGGER.debug("Waiting 1s after estabilishing connection")
+    await asyncio.sleep(1)
+
     return protocol

--- a/zigpy_znp/uart.py
+++ b/zigpy_znp/uart.py
@@ -255,7 +255,4 @@ async def connect(config: conf.ConfigType, api, *, toggle_rts=True) -> ZnpMtProt
 
     LOGGER.debug("Connected to %s at %s baud", port, baudrate)
 
-    LOGGER.debug("Waiting 1s after estabilishing connection")
-    await asyncio.sleep(1)
-
     return protocol

--- a/zigpy_znp/uart.py
+++ b/zigpy_znp/uart.py
@@ -238,18 +238,18 @@ async def connect(config: conf.ConfigType, api, *, toggle_rts=True) -> ZnpMtProt
     # Skips the bootloader on slaesh's CC2652R USB stick
     if toggle_rts:
         LOGGER.debug("Toggling RTS/CTS to skip CC2652R bootloader")
-        transport.serial.dsrdtr = False
-        transport.serial.rtscts = False
+        transport.serial.dtr = False
+        transport.serial.rts = False
 
         await asyncio.sleep(RTS_TOGGLE_DELAY)
 
-        transport.serial.dsrdtr = False
-        transport.serial.rtscts = True
+        transport.serial.dtr = False
+        transport.serial.rts = True
 
         await asyncio.sleep(RTS_TOGGLE_DELAY)
 
-        transport.serial.dsrdtr = False
-        transport.serial.rtscts = False
+        transport.serial.dtr = False
+        transport.serial.rts = False
 
         await asyncio.sleep(RTS_TOGGLE_DELAY)
 


### PR DESCRIPTION
Fix for #35 
Setting `dtr` and `rts` instead of `dsrdtr` and `rtscts`
And 1s delay before sending bootloader skip bytes.