### PR TITLE
Update README.md mention channels 11 and 13 under energy scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Channel energy (mean of 1 / 5):
  + Active Zigbee networks on a channel may still cause congestion
  + Using 26 in the USA may have lower TX power due to FCC regulations
  + Zigbee channels 15, 20, 25 fall between WiFi channels 1, 6, 11
- + Some Zigbee devices only join networks on channels 15, 20, and 25
+ + Some Zigbee devices only join networks on channels 11, 13, 15, 20, or 25
 ------------------------------------------------
  - 11    61.57%  #############################################################
  - 12    60.78%  ############################################################


### PR DESCRIPTION
Apparently most devices Legrand Netatmo will only joins on Zigbee channel 11 and one particular device only join on channel 13

@pipiche38 mentioned that only some Legrand / Netatmo devices work on the more common channel 15, but far from all.

https://github.com/pipiche38/Domoticz-Zigate-Wiki/blob/master/en-eng/Legrand-Netatmo-corner.md

* **_Channel 11 , pair all devices_**
* **_Channel 13, able to pair switch W/O neutral._**
* **_Channel 15, able to pair micromodule and switch W/O Neutral_**

This fact is also mentioned for these specific Legrand / Netatmo devices on blakadder Zigbee Device Compatibility Repository:

https://zigbee.blakadder.com/vendors.html