### PR TITLE
Add ZDO Mgmt Lqi and Rtg to the conversion schema

### DIFF
--- a/zigpy_znp/commands/zdo.py
+++ b/zigpy_znp/commands/zdo.py
@@ -134,10 +134,14 @@ class ZDO(t.CommandsBase, subsystem=t.Subsystem.ZDO):
         0x02,
         req_schema=(
             t.Param(
-                "DstAddr", t.NWK, "Short address of the device generating the inquiry",
+                "DstAddr",
+                t.NWK,
+                "Short address of the device generating the inquiry",
             ),
             t.Param(
-                "NWKAddrOfInterest", t.NWK, "Short address of the device being queried",
+                "NWKAddrOfInterest",
+                t.NWK,
+                "Short address of the device being queried",
             ),
         ),
         rsp_schema=t.STATUS_SCHEMA,
@@ -149,10 +153,14 @@ class ZDO(t.CommandsBase, subsystem=t.Subsystem.ZDO):
         0x03,
         req_schema=(
             t.Param(
-                "DstAddr", t.NWK, "Short address of the device generating the inquiry",
+                "DstAddr",
+                t.NWK,
+                "Short address of the device generating the inquiry",
             ),
             t.Param(
-                "NWKAddrOfInterest", t.NWK, "Short address of the device being queried",
+                "NWKAddrOfInterest",
+                t.NWK,
+                "Short address of the device being queried",
             ),
         ),
         rsp_schema=t.STATUS_SCHEMA,
@@ -164,10 +172,14 @@ class ZDO(t.CommandsBase, subsystem=t.Subsystem.ZDO):
         0x04,
         req_schema=(
             t.Param(
-                "DstAddr", t.NWK, "Short address of the device generating the inquiry",
+                "DstAddr",
+                t.NWK,
+                "Short address of the device generating the inquiry",
             ),
             t.Param(
-                "NWKAddrOfInterest", t.NWK, "Short address of the device being queried",
+                "NWKAddrOfInterest",
+                t.NWK,
+                "Short address of the device being queried",
             ),
             t.Param("Endpoint", t.uint8_t, "application endpoint the data is from"),
         ),
@@ -180,10 +192,14 @@ class ZDO(t.CommandsBase, subsystem=t.Subsystem.ZDO):
         0x05,
         req_schema=(
             t.Param(
-                "DstAddr", t.NWK, "Short address of the device generating the inquiry",
+                "DstAddr",
+                t.NWK,
+                "Short address of the device generating the inquiry",
             ),
             t.Param(
-                "NWKAddrOfInterest", t.NWK, "Short address of the device being queried",
+                "NWKAddrOfInterest",
+                t.NWK,
+                "Short address of the device being queried",
             ),
         ),
         rsp_schema=t.STATUS_SCHEMA,
@@ -195,10 +211,14 @@ class ZDO(t.CommandsBase, subsystem=t.Subsystem.ZDO):
         0x06,
         req_schema=(
             t.Param(
-                "DstAddr", t.NWK, "Short address of the device generating the inquiry",
+                "DstAddr",
+                t.NWK,
+                "Short address of the device generating the inquiry",
             ),
             t.Param(
-                "NWKAddrOfInterest", t.NWK, "Short address of the device being queried",
+                "NWKAddrOfInterest",
+                t.NWK,
+                "Short address of the device being queried",
             ),
             t.Param("ProfileId", t.uint16_t, "profile id of the device"),
             t.Param("InputClusters", t.ClusterIdList, "Input cluster id list"),
@@ -213,10 +233,14 @@ class ZDO(t.CommandsBase, subsystem=t.Subsystem.ZDO):
         0x07,
         req_schema=(
             t.Param(
-                "DstAddr", t.NWK, "Short address of the device generating the inquiry",
+                "DstAddr",
+                t.NWK,
+                "Short address of the device generating the inquiry",
             ),
             t.Param(
-                "NWKAddrOfInterest", t.NWK, "Short address of the device being queried",
+                "NWKAddrOfInterest",
+                t.NWK,
+                "Short address of the device being queried",
             ),
         ),
         rsp_schema=t.STATUS_SCHEMA,
@@ -228,10 +252,14 @@ class ZDO(t.CommandsBase, subsystem=t.Subsystem.ZDO):
         0x08,
         req_schema=(
             t.Param(
-                "DstAddr", t.NWK, "Short address of the device generating the inquiry",
+                "DstAddr",
+                t.NWK,
+                "Short address of the device generating the inquiry",
             ),
             t.Param(
-                "NWKAddrOfInterest", t.NWK, "Short address of the device being queried",
+                "NWKAddrOfInterest",
+                t.NWK,
+                "Short address of the device being queried",
             ),
         ),
         rsp_schema=t.STATUS_SCHEMA,
@@ -293,7 +321,9 @@ class ZDO(t.CommandsBase, subsystem=t.Subsystem.ZDO):
         0x20,
         req_schema=(
             t.Param(
-                "DstAddr", t.NWK, "Short address of the device generating the request",
+                "DstAddr",
+                t.NWK,
+                "Short address of the device generating the request",
             ),
             t.Param(
                 "LocalCoordinator",
@@ -832,10 +862,14 @@ class ZDO(t.CommandsBase, subsystem=t.Subsystem.ZDO):
         req_schema=(
             t.Param("NWK", t.NWK, "Short address of the destination"),
             t.Param(
-                "NWKAddrOfInterest", t.NWK, "Short address of the device being queried",
+                "NWKAddrOfInterest",
+                t.NWK,
+                "Short address of the device being queried",
             ),
             t.Param(
-                "Cmd", t.uint8_t, "A valid Cluser ID command as specified by profile",
+                "Cmd",
+                t.uint8_t,
+                "A valid Cluser ID command as specified by profile",
             ),
         ),
         rsp_schema=t.STATUS_SCHEMA,
@@ -1074,7 +1108,7 @@ class ZDO(t.CommandsBase, subsystem=t.Subsystem.ZDO):
             t.Param(
                 "Status", t.ZDOStatus, "Status is either Success (0) or Failure (1)"
             ),
-            t.Param("Neighbours", zigpy.zdo.types.Neighbors, "Neighbours"),
+            t.Param("Neighbors", zigpy.zdo.types.Neighbors, "Neighbors"),
         ),
     )
 
@@ -1264,7 +1298,9 @@ class ZDO(t.CommandsBase, subsystem=t.Subsystem.ZDO):
                 "NWK", t.NWK, "Short address of the source of the leave indication"
             ),
             t.Param(
-                "IEEE", t.EUI64, "IEEE address of the source of the leave indication",
+                "IEEE",
+                t.EUI64,
+                "IEEE address of the source of the leave indication",
             ),
             t.Param("Request", t.Bool, "True -- request, False -- indication"),
             t.Param("Remove", t.Bool, "True -- Remove children"),
@@ -1280,7 +1316,9 @@ class ZDO(t.CommandsBase, subsystem=t.Subsystem.ZDO):
         rsp_schema=(
             t.Param("Src", t.NWK, "Source address of the ZDO message"),
             t.Param(
-                "IsBroadcast", t.Bool, "Indicates whether the message was a broadcast",
+                "IsBroadcast",
+                t.Bool,
+                "Indicates whether the message was a broadcast",
             ),
             t.Param("ClusterId", t.ClusterId, "Cluster Id of this ZDO message"),
             t.Param("SecurityUse", t.uint8_t, "Not used"),

--- a/zigpy_znp/types/named.py
+++ b/zigpy_znp/types/named.py
@@ -187,6 +187,8 @@ class Status(MissingEnumMixin, basic.enum_uint8):
 
     MALFORMED_CMD = 0x80
     UNSUP_CLUSTER_CMD = 0x81
+    # 0x84 The requested optional feature is not supported on the target device.
+    NOT_SUPPORTED = 0x84
 
     OTA_ABORT = 0x95
     OTA_IMAGE_INVALID = 0x96

--- a/zigpy_znp/zigbee/zdo_converters.py
+++ b/zigpy_znp/zigbee/zdo_converters.py
@@ -116,4 +116,22 @@ ZDO_CONVERTERS = {
         (lambda addr: c.ZDO.BindRsp.Callback(partial=True, Src=addr)),
         (lambda rsp: (ZDOCmd.Bind_rsp, {"Status": rsp.Status})),
     ),
+        ZDOCmd.Mgmt_Lqi_req: (
+        (
+            lambda addr, StartIndex: (
+                c.ZDO.MgmtLqiReq.Req(Dst=addr, StartIndex=StartIndex,)
+            )
+        ),
+        (lambda addr: c.ZDO.MgmtLqiRsp.Callback(partial=True, Src=addr)),
+        (lambda rsp: (ZDOCmd.Mgmt_Lqi_rsp, {"Status": rsp.Status})),
+    ),
+    ZDOCmd.Mgmt_Rtg_req: (
+        (
+            lambda addr, StartIndex: (
+                c.ZDO.MgmtLqiReq.Req(Dst=addr, StartIndex=StartIndex,)
+            )
+        ),
+        (lambda addr: c.ZDO.MgmtRtgRsp.Callback(partial=True, Src=addr)),
+        (lambda rsp: (ZDOCmd.Mgmt_Rtg_rsp, {"Status": rsp.Status})),
+    ),
 }

--- a/zigpy_znp/zigbee/zdo_converters.py
+++ b/zigpy_znp/zigbee/zdo_converters.py
@@ -116,22 +116,38 @@ ZDO_CONVERTERS = {
         (lambda addr: c.ZDO.BindRsp.Callback(partial=True, Src=addr)),
         (lambda rsp: (ZDOCmd.Bind_rsp, {"Status": rsp.Status})),
     ),
-        ZDOCmd.Mgmt_Lqi_req: (
+    ZDOCmd.Mgmt_Lqi_req: (
         (
             lambda addr, StartIndex: (
-                c.ZDO.MgmtLqiReq.Req(Dst=addr, StartIndex=StartIndex,)
+                c.ZDO.MgmtLqiReq.Req(
+                    Dst=addr,
+                    StartIndex=StartIndex,
+                )
             )
         ),
         (lambda addr: c.ZDO.MgmtLqiRsp.Callback(partial=True, Src=addr)),
-        (lambda rsp: (ZDOCmd.Mgmt_Lqi_rsp, {"Status": rsp.Status})),
+        (
+            lambda rsp: (
+                ZDOCmd.Mgmt_Lqi_rsp,
+                {"Status": rsp.Status, "Neighbors": rsp.Neighbors},
+            )
+        ),
     ),
     ZDOCmd.Mgmt_Rtg_req: (
         (
             lambda addr, StartIndex: (
-                c.ZDO.MgmtLqiReq.Req(Dst=addr, StartIndex=StartIndex,)
+                c.ZDO.MgmtRtgReq.Req(
+                    Dst=addr,
+                    StartIndex=StartIndex,
+                )
             )
         ),
         (lambda addr: c.ZDO.MgmtRtgRsp.Callback(partial=True, Src=addr)),
-        (lambda rsp: (ZDOCmd.Mgmt_Rtg_rsp, {"Status": rsp.Status})),
+        (
+            lambda rsp: (
+                ZDOCmd.Mgmt_Rtg_rsp,
+                {"Status": rsp.Status, "Routes": rsp.Routes},
+            )
+        ),
     ),
 }


### PR DESCRIPTION
Mgmt Lqi tested in a ZNP stack environment.
Rtg untested.  It follows similar mapping to Lqi.

Non fatal exception occurs when a device returns a ZDO NOT_IMPLEMENTED as the schema specifies the Neighbor structure as a mandatory part of the response.

2020-09-24 17:40:26 ERROR (MainThread) [zigpy_znp.uart] Received an exception while passing frame to API
Traceback (most recent call last):
  File "/home/samantha/github/core/venv/lib/python3.7/site-packages/zigpy_znp/uart.py", line 83, in data_received
    self._api.frame_received(frame.payload)
  File "/home/samantha/github/core/venv/lib/python3.7/site-packages/zigpy_znp/api.py", line 350, in frame_received
    command = command_cls.from_frame(frame)
  File "/home/samantha/github/core/venv/lib/python3.7/site-packages/zigpy_znp/types/commands.py", line 415, in from_frame
    f"Data has been consumed but required parameters remain: {param}"
ValueError: Data has been consumed but required parameters remain: Param(name='Neighbors', type=<class 'zigpy.zdo.types.Neighbors'>, description='Neighbors', optional=False)