### PR TITLE
Add ZDO Mgmt Lqi & Rst schemas

### DIFF
--- a/zigpy_znp/commands/zdo.py
+++ b/zigpy_znp/commands/zdo.py
@@ -1109,7 +1109,7 @@ class ZDO(t.CommandsBase, subsystem=t.Subsystem.ZDO):
             t.Param(
                 "Status", t.ZDOStatus, "Status is either Success (0) or Failure (1)"
             ),
-            t.Param("Neighbours", zigpy.zdo.types.Neighbors, "Neighbours"),
+            t.Param("Neighbors", zigpy.zdo.types.Neighbors, "Neighbors"),
         ),
     )
 

--- a/zigpy_znp/types/named.py
+++ b/zigpy_znp/types/named.py
@@ -186,8 +186,6 @@ class Status(MissingEnumMixin, basic.enum_uint8):
 
     MALFORMED_CMD = 0x80
     UNSUP_CLUSTER_CMD = 0x81
-    # The requested optional feature is not supported on the target device.
-    NOT_SUPPORTED = 0x84
 
     OTA_ABORT = 0x95
     OTA_IMAGE_INVALID = 0x96

--- a/zigpy_znp/types/named.py
+++ b/zigpy_znp/types/named.py
@@ -186,6 +186,8 @@ class Status(MissingEnumMixin, basic.enum_uint8):
 
     MALFORMED_CMD = 0x80
     UNSUP_CLUSTER_CMD = 0x81
+    # The requested optional feature is not supported on the target device.
+    NOT_SUPPORTED = 0x84
 
     OTA_ABORT = 0x95
     OTA_IMAGE_INVALID = 0x96

--- a/zigpy_znp/zigbee/zdo_converters.py
+++ b/zigpy_znp/zigbee/zdo_converters.py
@@ -116,4 +116,33 @@ ZDO_CONVERTERS = {
         (lambda addr: c.ZDO.BindRsp.Callback(partial=True, Src=addr)),
         (lambda rsp: (ZDOCmd.Bind_rsp, {"Status": rsp.Status})),
     ),
+    ZDOCmd.Mgmt_Lqi_req: (
+        (
+            lambda addr, device, StartIndex: (
+                c.ZDO.MgmtLqiReq.Req(
+                    Dst=addr,
+                    StartIndex=StartIndex,
+                )
+            )
+        ),
+        (lambda addr: c.ZDO.MgmtLqiRsp.Callback(partial=True, Src=addr)),
+        (
+            lambda rsp: (
+                ZDOCmd.Mgmt_Lqi_rsp,
+                {"Status": rsp.Status, "Neighbors": rsp.Neighbors},
+            )
+        ),
+    ),
+    ZDOCmd.Mgmt_Rtg_req: (
+        (
+            lambda addr, StartIndex: (
+                c.ZDO.MgmtLqiReq.Req(
+                    Dst=addr,
+                    StartIndex=StartIndex,
+                )
+            )
+        ),
+        (lambda addr: c.ZDO.MgmtRtgRsp.Callback(partial=True, Src=addr)),
+        (lambda rsp: (ZDOCmd.Mgmt_Rtg_rsp, {"Status": rsp.Status})),
+    ),
 }


### PR DESCRIPTION
Mgmt Lqi tested in a ZNP stack environment.
Rtg untested.  It follows similar mapping to Lqi.

Non fatal exception occurs when a device returns a ZDO NOT_IMPLEMENTED as the schema specifies the Neighbor structure as a mandatory part of the response.

2020-09-24 17:40:26 ERROR (MainThread) [zigpy_znp.uart] Received an exception while passing frame to API
Traceback (most recent call last):
  File "/home/samantha/github/core/venv/lib/python3.7/site-packages/zigpy_znp/uart.py", line 83, in data_received
    self._api.frame_received(frame.payload)
  File "/home/samantha/github/core/venv/lib/python3.7/site-packages/zigpy_znp/api.py", line 350, in frame_received
    command = command_cls.from_frame(frame)
  File "/home/samantha/github/core/venv/lib/python3.7/site-packages/zigpy_znp/types/commands.py", line 415, in from_frame
    f"Data has been consumed but required parameters remain: {param}"
ValueError: Data has been consumed but required parameters remain: Param(name='Neighbors', type=<class 'zigpy.zdo.types.Neighbors'>, description='Neighbors', optional=False)