### PR TITLE
Update setup.py adding "pyusb>=1.1.0" requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
     packages=find_packages(exclude=["tests", "tests.*"]),
     install_requires=[
         "pyserial-asyncio",
+        "pyusb>=1.1.0",
         "zigpy>=0.25.0",
         "async_timeout",
         "voluptuous",


### PR DESCRIPTION
Update setup.py adding "pyusb>=1.1.0" requirement as probably does not hurt have latest pyusb / libusb installed when trying to add USB adapters.

Reference https://github.com/zigpy/zigpy-zigate/issues/71 and https://github.com/home-assistant/home-assistant.io/pull/15829