### PR TITLE
Treat messages from unknown devices as implicit joins and discover IEEE addresses

### DIFF
--- a/tests/api/test_response.py
+++ b/tests/api/test_response.py
@@ -5,7 +5,7 @@ import async_timeout
 
 import zigpy_znp.types as t
 import zigpy_znp.commands as c
-from zigpy_znp.api import _deduplicate_commands
+from zigpy_znp.utils import deduplicate_commands
 
 pytestmark = [pytest.mark.asyncio]
 
@@ -215,15 +215,15 @@ async def test_command_deduplication_simple():
     c1 = c.SYS.Ping.Rsp(partial=True)
     c2 = c.UTIL.TimeAlive.Rsp(Seconds=12)
 
-    assert _deduplicate_commands([]) == ()
-    assert _deduplicate_commands([c1]) == (c1,)
-    assert _deduplicate_commands([c1, c1]) == (c1,)
-    assert _deduplicate_commands([c1, c2]) == (c1, c2)
-    assert _deduplicate_commands([c2, c1, c2]) == (c2, c1)
+    assert deduplicate_commands([]) == ()
+    assert deduplicate_commands([c1]) == (c1,)
+    assert deduplicate_commands([c1, c1]) == (c1,)
+    assert deduplicate_commands([c1, c2]) == (c1, c2)
+    assert deduplicate_commands([c2, c1, c2]) == (c2, c1)
 
 
 async def test_command_deduplication_complex():
-    result = _deduplicate_commands(
+    result = deduplicate_commands(
         [
             c.SYS.Ping.Rsp(Capabilities=t.MTCapabilities.SYS),
             # Duplicating matching commands shouldn't do anything
@@ -302,7 +302,7 @@ async def test_response_callbacks(connected_znp, event_loop, mocker):
         c.UTIL.TimeAlive.Rsp(Seconds=10),
     ]
 
-    assert set(_deduplicate_commands(responses)) == {
+    assert set(deduplicate_commands(responses)) == {
         c.SYS.Ping.Rsp(partial=True),
         c.UTIL.TimeAlive.Rsp(Seconds=12),
         c.UTIL.TimeAlive.Rsp(Seconds=10),

--- a/tests/application/test_startup.py
+++ b/tests/application/test_startup.py
@@ -71,6 +71,7 @@ async def test_info(
     assert app.channel is None
     assert app.channels is None
     assert app.network_key is None
+    assert app.network_key_seq is None
 
     await app.startup(auto_form=False)
 
@@ -84,6 +85,7 @@ async def test_info(
     assert app.channel == channel
     assert app.channels == channels
     assert app.network_key == network_key
+    assert app.network_key_seq == 0
 
     assert app.zigpy_device.manufacturer == "Texas Instruments"
     assert app.zigpy_device.model == model

--- a/tests/application/test_zigpy_callbacks.py
+++ b/tests/application/test_zigpy_callbacks.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 
 import pytest
@@ -6,9 +7,20 @@ from zigpy.zdo.types import ZDOCmd
 import zigpy_znp.types as t
 import zigpy_znp.commands as c
 
-from ..conftest import FORMED_DEVICES
+from ..conftest import FORMED_DEVICES, CoroutineMock
 
 pytestmark = [pytest.mark.asyncio]
+
+
+def awaitable_mock(return_value):
+    mock_called = asyncio.get_running_loop().create_future()
+
+    def side_effect(*args, **kwargs):
+        mock_called.set_result((args, kwargs))
+
+        return return_value
+
+    return mock_called, CoroutineMock(side_effect=side_effect)
 
 
 @pytest.mark.parametrize("device", FORMED_DEVICES)
@@ -17,9 +29,12 @@ async def test_on_zdo_relays_message_callback(device, make_application, mocker):
     await app.startup(auto_form=False)
 
     device = mocker.Mock()
-    mocker.patch.object(app, "get_device", return_value=device)
+    discover_called, discover_mock = awaitable_mock(return_value=device)
+    mocker.patch.object(app, "_get_or_discover_device", new=discover_mock)
 
     znp_server.send(c.ZDO.SrcRtgInd.Callback(DstAddr=0x1234, Relays=[0x5678, 0xABCD]))
+
+    await discover_called
     assert device.relays == [0x5678, 0xABCD]
 
     await app.shutdown()
@@ -32,8 +47,13 @@ async def test_on_zdo_relays_message_callback_unknown(
     app, znp_server = make_application(server_cls=device)
     await app.startup(auto_form=False)
 
+    discover_called, discover_mock = awaitable_mock(return_value=None)
+    mocker.patch.object(app, "_get_or_discover_device", new=discover_mock)
+
     caplog.set_level(logging.WARNING)
     znp_server.send(c.ZDO.SrcRtgInd.Callback(DstAddr=0x1234, Relays=[0x5678, 0xABCD]))
+
+    await discover_called
     assert "unknown device" in caplog.text
 
     await app.shutdown()
@@ -98,12 +118,10 @@ async def test_on_af_message_callback(device, make_application, mocker):
     await app.startup(auto_form=False)
 
     device = mocker.Mock()
-    mocker.patch.object(
-        app,
-        "get_device",
-        side_effect=[device, device, device, KeyError("No such device")],
-    )
+    discover_called, discover_mock = awaitable_mock(return_value=device)
+    mocker.patch.object(app, "_get_or_discover_device", new=discover_mock)
     mocker.patch.object(app, "handle_message")
+    mocker.patch.object(app, "get_device")
 
     af_message = c.AF.IncomingMsg.Callback(
         GroupId=1,
@@ -123,43 +141,56 @@ async def test_on_af_message_callback(device, make_application, mocker):
 
     # Normal message
     znp_server.send(af_message)
-    app.get_device.assert_called_once_with(nwk=0xABCD)
+
+    await discover_called
     device.radio_details.assert_called_once_with(lqi=19, rssi=None)
     app.handle_message.assert_called_once_with(
         sender=device, profile=260, cluster=2, src_ep=4, dst_ep=1, message=b"test"
     )
 
-    # ZLL message
     device.reset_mock()
     app.handle_message.reset_mock()
     app.get_device.reset_mock()
 
+    # ZLL message
+    discover_called, discover_mock = awaitable_mock(return_value=device)
+    mocker.patch.object(app, "_get_or_discover_device", new=discover_mock)
+
     znp_server.send(af_message.replace(DstEndpoint=2))
-    app.get_device.assert_called_once_with(nwk=0xABCD)
+
+    await discover_called
     device.radio_details.assert_called_once_with(lqi=19, rssi=None)
     app.handle_message.assert_called_once_with(
         sender=device, profile=49246, cluster=2, src_ep=4, dst_ep=2, message=b"test"
     )
 
-    # Message on an unknown endpoint (is this possible?)
     device.reset_mock()
     app.handle_message.reset_mock()
     app.get_device.reset_mock()
 
+    # Message on an unknown endpoint (is this possible?)
+    discover_called, discover_mock = awaitable_mock(return_value=device)
+    mocker.patch.object(app, "_get_or_discover_device", new=discover_mock)
+
     znp_server.send(af_message.replace(DstEndpoint=3))
-    app.get_device.assert_called_once_with(nwk=0xABCD)
+
+    await discover_called
     device.radio_details.assert_called_once_with(lqi=19, rssi=None)
     app.handle_message.assert_called_once_with(
         sender=device, profile=260, cluster=2, src_ep=4, dst_ep=3, message=b"test"
     )
 
-    # Message from an unknown device
     device.reset_mock()
     app.handle_message.reset_mock()
     app.get_device.reset_mock()
 
+    # Message from an unknown device
+    discover_called, discover_mock = awaitable_mock(return_value=None)
+    mocker.patch.object(app, "_get_or_discover_device", new=discover_mock)
+
     znp_server.send(af_message)
-    app.get_device.assert_called_once_with(nwk=0xABCD)
+
+    await discover_called
     assert device.radio_details.call_count == 0
     assert app.handle_message.call_count == 0
 

--- a/zigpy_znp/api.py
+++ b/zigpy_znp/api.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
 
 import time
-import typing
 import asyncio
 import logging
 import itertools
 import contextlib
-import dataclasses
 from collections import Counter, defaultdict
 
 import async_timeout
@@ -17,6 +15,11 @@ import zigpy_znp.logger as log
 import zigpy_znp.commands as c
 from zigpy_znp import uart
 from zigpy_znp.nvram import NVRAMHelper
+from zigpy_znp.utils import (
+    BaseResponseListener,
+    OneShotResponseListener,
+    CallbackResponseListener,
+)
 from zigpy_znp.frames import GeneralFrame
 from zigpy_znp.znp.utils import NetworkInfo, load_network_info, detect_zstack_version
 from zigpy_znp.exceptions import CommandNotRecognized, InvalidCommandResponse
@@ -24,147 +27,6 @@ from zigpy_znp.exceptions import CommandNotRecognized, InvalidCommandResponse
 LOGGER = logging.getLogger(__name__)
 AFTER_CONNECT_DELAY = 1  # seconds
 STARTUP_DELAY = 1  # seconds
-
-
-def _deduplicate_commands(
-    commands: typing.Iterable[t.CommandBase],
-) -> tuple[t.CommandBase]:
-    """
-    Deduplicates an iterable of commands by folding more-specific commands into less-
-    specific commands. Used to avoid triggering callbacks multiple times per packet.
-    """
-
-    # We essentially need to find the "maximal" commands, if you treat the relationship
-    # between two commands as a partial order.
-    maximal_commands = []
-
-    # Command matching as a relation forms a partially ordered set.
-    for command in commands:
-        for index, other_command in enumerate(maximal_commands):
-            if other_command.matches(command):
-                # If the other command matches us, we are redundant
-                break
-            elif command.matches(other_command):
-                # If we match another command, we replace it
-                maximal_commands[index] = command
-                break
-            else:
-                # Otherwise, we keep looking
-                continue  # pragma: no cover
-        else:
-            # If we matched nothing and nothing matched us, we extend the list
-            maximal_commands.append(command)
-
-    # The start of each chain is the maximal element
-    return tuple(maximal_commands)
-
-
-@dataclasses.dataclass(frozen=True)
-class BaseResponseListener:
-    matching_commands: tuple[t.CommandBase]
-
-    def __post_init__(self):
-        commands = _deduplicate_commands(self.matching_commands)
-
-        if not commands:
-            raise ValueError("Cannot create a listener without any matching commands")
-
-        # We're frozen so __setattr__ is disallowed
-        object.__setattr__(self, "matching_commands", commands)
-
-    def matching_headers(self) -> set[t.CommandHeader]:
-        """
-        Returns the set of Z-Stack MT command headers for all the matching commands.
-        """
-
-        return {response.header for response in self.matching_commands}
-
-    def resolve(self, response: t.CommandBase) -> bool:
-        """
-        Attempts to resolve the listener with a given response. Can be called with any
-        command as an argument, including ones we don't match.
-        """
-
-        if not any(c.matches(response) for c in self.matching_commands):
-            return False
-
-        return self._resolve(response)
-
-    def _resolve(self, response: t.CommandBase) -> bool:
-        """
-        Implemented by subclasses to handle matched commands.
-
-        Return value indicates whether or not the listener has actually resolved,
-        which can sometimes be unavoidable.
-        """
-
-        raise NotImplementedError()  # pragma: no cover
-
-    def cancel(self):
-        """
-        Implement by subclasses to cancel the listener.
-
-        Return value indicates whether or not the listener is cancelable.
-        """
-
-        raise NotImplementedError()  # pragma: no cover
-
-
-@dataclasses.dataclass(frozen=True)
-class OneShotResponseListener(BaseResponseListener):
-    """
-    A response listener that resolves a single future exactly once.
-    """
-
-    future: asyncio.Future = dataclasses.field(
-        default_factory=lambda: asyncio.get_running_loop().create_future()
-    )
-
-    def _resolve(self, response: t.CommandBase) -> bool:
-        if self.future.done():
-            # This happens if the UART receives multiple packets during the same
-            # event loop step and all of them match this listener. Our Future's
-            # add_done_callback will not fire synchronously and thus the listener
-            # is never properly removed. This isn't going to break anything.
-            LOGGER.debug("Future already has a result set: %s", self.future)
-            return False
-
-        self.future.set_result(response)
-        return True
-
-    def cancel(self):
-        if not self.future.done():
-            self.future.cancel()
-
-        return True
-
-
-@dataclasses.dataclass(frozen=True)
-class CallbackResponseListener(BaseResponseListener):
-    """
-    A response listener with a sync or async callback that is never resolved.
-    """
-
-    callback: typing.Callable[[t.CommandBase], typing.Any]
-
-    def _resolve(self, response: t.CommandBase) -> bool:
-        try:
-            result = self.callback(response)
-
-            # Run coroutines in the background
-            if asyncio.iscoroutine(result):
-                asyncio.create_task(result)
-        except Exception:
-            LOGGER.warning(
-                "Caught an exception while executing callback", exc_info=True
-            )
-
-        # Callbacks are always resolved
-        return True
-
-    def cancel(self):
-        # You can't cancel a callback
-        return False
 
 
 class ZNP:

--- a/zigpy_znp/commands/zdo.py
+++ b/zigpy_znp/commands/zdo.py
@@ -141,6 +141,11 @@ class NullableNodeDescriptor(zigpy.zdo.types.NodeDescriptor):
         return super().serialize()
 
 
+class AddrRequestType(t.enum_uint8):
+    SINGLE = 0x00
+    EXTENDED = 0x01
+
+
 class ZDO(t.CommandsBase, subsystem=t.Subsystem.ZDO):
     # send a "Network Address Request". This message sends a broadcast message looking
     # for a 16 bit address with a known 64 bit IEEE address. You must subscribe to
@@ -156,7 +161,7 @@ class ZDO(t.CommandsBase, subsystem=t.Subsystem.ZDO):
             ),
             t.Param(
                 "RequestType",
-                t.uint8_t,
+                AddrRequestType,
                 "0x00 -- single device request, 0x01 -- Extended",
             ),
             t.Param(
@@ -174,7 +179,7 @@ class ZDO(t.CommandsBase, subsystem=t.Subsystem.ZDO):
             t.Param("NWK", t.NWK, "Short address of the device"),
             t.Param(
                 "RequestType",
-                t.uint8_t,
+                AddrRequestType,
                 "0x00 -- single device request, 0x01 -- Extended",
             ),
             t.Param(

--- a/zigpy_znp/utils.py
+++ b/zigpy_znp/utils.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import typing
+import asyncio
+import logging
+import functools
+import dataclasses
+
+import zigpy_znp.types as t
+
+LOGGER = logging.getLogger(__name__)
+
+
+def deduplicate_commands(
+    commands: typing.Iterable[t.CommandBase],
+) -> tuple[t.CommandBase]:
+    """
+    Deduplicates an iterable of commands by folding more-specific commands into less-
+    specific commands. Used to avoid triggering callbacks multiple times per packet.
+    """
+
+    # We essentially need to find the "maximal" commands, if you treat the relationship
+    # between two commands as a partial order.
+    maximal_commands = []
+
+    # Command matching as a relation forms a partially ordered set.
+    for command in commands:
+        for index, other_command in enumerate(maximal_commands):
+            if other_command.matches(command):
+                # If the other command matches us, we are redundant
+                break
+            elif command.matches(other_command):
+                # If we match another command, we replace it
+                maximal_commands[index] = command
+                break
+            else:
+                # Otherwise, we keep looking
+                continue  # pragma: no cover
+        else:
+            # If we matched nothing and nothing matched us, we extend the list
+            maximal_commands.append(command)
+
+    # The start of each chain is the maximal element
+    return tuple(maximal_commands)
+
+
+@dataclasses.dataclass(frozen=True)
+class BaseResponseListener:
+    matching_commands: tuple[t.CommandBase]
+
+    def __post_init__(self):
+        commands = deduplicate_commands(self.matching_commands)
+
+        if not commands:
+            raise ValueError("Cannot create a listener without any matching commands")
+
+        # We're frozen so __setattr__ is disallowed
+        object.__setattr__(self, "matching_commands", commands)
+
+    def matching_headers(self) -> set[t.CommandHeader]:
+        """
+        Returns the set of Z-Stack MT command headers for all the matching commands.
+        """
+
+        return {response.header for response in self.matching_commands}
+
+    def resolve(self, response: t.CommandBase) -> bool:
+        """
+        Attempts to resolve the listener with a given response. Can be called with any
+        command as an argument, including ones we don't match.
+        """
+
+        if not any(c.matches(response) for c in self.matching_commands):
+            return False
+
+        return self._resolve(response)
+
+    def _resolve(self, response: t.CommandBase) -> bool:
+        """
+        Implemented by subclasses to handle matched commands.
+
+        Return value indicates whether or not the listener has actually resolved,
+        which can sometimes be unavoidable.
+        """
+
+        raise NotImplementedError()  # pragma: no cover
+
+    def cancel(self):
+        """
+        Implement by subclasses to cancel the listener.
+
+        Return value indicates whether or not the listener is cancelable.
+        """
+
+        raise NotImplementedError()  # pragma: no cover
+
+
+@dataclasses.dataclass(frozen=True)
+class OneShotResponseListener(BaseResponseListener):
+    """
+    A response listener that resolves a single future exactly once.
+    """
+
+    future: asyncio.Future = dataclasses.field(
+        default_factory=lambda: asyncio.get_running_loop().create_future()
+    )
+
+    def _resolve(self, response: t.CommandBase) -> bool:
+        if self.future.done():
+            # This happens if the UART receives multiple packets during the same
+            # event loop step and all of them match this listener. Our Future's
+            # add_done_callback will not fire synchronously and thus the listener
+            # is never properly removed. This isn't going to break anything.
+            LOGGER.debug("Future already has a result set: %s", self.future)
+            return False
+
+        self.future.set_result(response)
+        return True
+
+    def cancel(self):
+        if not self.future.done():
+            self.future.cancel()
+
+        return True
+
+
+@dataclasses.dataclass(frozen=True)
+class CallbackResponseListener(BaseResponseListener):
+    """
+    A response listener with a sync or async callback that is never resolved.
+    """
+
+    callback: typing.Callable[[t.CommandBase], typing.Any]
+
+    def _resolve(self, response: t.CommandBase) -> bool:
+        try:
+            result = self.callback(response)
+
+            # Run coroutines in the background
+            if asyncio.iscoroutine(result):
+                asyncio.create_task(result)
+        except Exception:
+            LOGGER.warning(
+                "Caught an exception while executing callback", exc_info=True
+            )
+
+        # Callbacks are always resolved
+        return True
+
+    def cancel(self):
+        # You can't cancel a callback
+        return False
+
+
+def combine_concurrent_calls(function):
+    """
+    Decorator that allows concurrent calls to expensive coroutines to share a result.
+    """
+
+    futures = {}
+
+    @functools.wraps(function)
+    async def replacement(*args, **kwargs):
+        # XXX: all args and kwargs are assumed to be hashable
+        key = (tuple(args), tuple([(k, v) for k, v in kwargs.items()]))
+
+        if key in futures:
+            return await futures[key]
+
+        future = futures[key] = asyncio.get_running_loop().create_future()
+
+        try:
+            result = await function(*args, **kwargs)
+        except Exception as e:
+            future.set_exception(e)
+            raise
+        else:
+            future.set_result(result)
+            return result
+        finally:
+            del futures[key]
+
+    return replacement

--- a/zigpy_znp/zigbee/application.py
+++ b/zigpy_znp/zigbee/application.py
@@ -1016,9 +1016,8 @@ class ControllerApplication(zigpy.application.ControllerApplication):
     async def _get_or_discover_device(self, nwk: t.NWK) -> zigpy.device.Device | None:
         """
         Finds a device by its NWK address. If a device does not exist in the zigpy
-        database, attempt to look up its new NWK address. If joins are currently allowed
-        then the device will be treated as a new join if it does not exist in the zigpy
-        database.
+        database, attempt to look up its new NWK address. If it does not exist in the
+        zigpy database, treat the device as a new join.
         """
 
         try:
@@ -1044,7 +1043,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
                 timeout=5,  # We don't want to wait forever
             )
         except asyncio.TimeoutError:
-            return
+            return None
 
         ieee = ieee_addr_rsp.IEEE
 

--- a/zigpy_znp/zigbee/application.py
+++ b/zigpy_znp/zigbee/application.py
@@ -1081,11 +1081,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         try:
             device = self.get_device(ieee=ieee)
         except KeyError:
-            if self._permit_joins_task.done():
-                LOGGER.warning("Ignoring device because joins are not permitted")
-                return
-
-            LOGGER.debug("Joins are permitted, treating unknown device as a new join")
+            LOGGER.debug("Treating unknown device as a new join")
             self.handle_join(nwk=nwk, ieee=ieee, parent_nwk=None)
 
             return self.get_device(ieee=ieee)


### PR DESCRIPTION
Devices that somehow manage to change their NWK address without notifying the coordinator are impossible to contact. Instead of dropping packets from them, we can discover their IEEE address and either update the NWK in zigpy's database or treat the device as a new join.

This allows for ZHA to be started up with a completely "unknown" network and for it to pick up devices as they're used.
