### PR TITLE
Properly handle older Z-Stack `SYS.SetTxPower` responses

### DIFF
--- a/zigpy_znp/commands/sys.py
+++ b/zigpy_znp/commands/sys.py
@@ -418,10 +418,11 @@ class SYS(t.CommandsBase, subsystem=t.Subsystem.SYS):
         t.CommandType.SREQ,
         0x14,
         req_schema=(t.Param("TXPower", t.int8s, "Requested TX power setting, in dBm"),),
-        # While the docs say "the returned TX power is the actual setting applied to
-        # the radio - nearest characterized value for the specific radio.", the code
-        # matches the documentation.
-        rsp_schema=t.STATUS_SCHEMA,
+        # XXX: Z-Stack 3.30+ returns SUCCESS or INVALID_PARAMETER.
+        #      Z-Stack 1.2 and 3.0 return the cloest TX power setting.
+        rsp_schema=(
+            t.Param("StatusOrPower", t.int8s, "Status code or applied power setting"),
+        ),
     )
 
     # initialize the statistics table in NV memory

--- a/zigpy_znp/config.py
+++ b/zigpy_znp/config.py
@@ -63,7 +63,7 @@ CONFIG_SCHEMA = CONFIG_SCHEMA.extend(
         vol.Optional(CONF_ZNP_CONFIG, default={}): vol.Schema(
             {
                 vol.Optional(CONF_TX_POWER, default=None): vol.Any(
-                    None, vol.All(int, vol.Range(min=-22, max=19))
+                    None, vol.All(int, vol.Range(min=-22, max=22))
                 ),
                 vol.Optional(CONF_SREQ_TIMEOUT, default=15): VolPositiveNumber,
                 vol.Optional(CONF_ARSP_TIMEOUT, default=30): VolPositiveNumber,


### PR DESCRIPTION
Older Z-Stack releases reply to `SYS.SetTxPower.Req` with the set power level instead of a `SUCCESS` / `INVALID_PARAMETER` status code.

Fixes #81.