### PR TITLE
Syncup with zigpy==0.37.0 changes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     install_requires=[
         'pyserial-asyncio; platform_system!="Windows"',
         'pyserial-asyncio!=0.5; platform_system=="Windows"',  # 0.5 broke writes
-        "zigpy>=0.34.0",
+        "zigpy>=0.37.0",
         "async_timeout",
         "voluptuous",
         "coloredlogs",

--- a/tests/application/test_startup.py
+++ b/tests/application/test_startup.py
@@ -67,8 +67,8 @@ async def test_info(
     app, znp_server = make_application(server_cls=device)
 
     # These should not raise any errors even if our NIB is empty
-    assert app.pan_id is None
-    assert app.extended_pan_id is None
+    assert app.pan_id == 0xFFFE  # unknown NWK ID
+    assert app.extended_pan_id == t.EUI64.convert("ff:ff:ff:ff:ff:ff:ff:ff")
     assert app.channel is None
     assert app.channels is None
     assert app.network_key is None

--- a/zigpy_znp/zigbee/application.py
+++ b/zigpy_znp/zigbee/application.py
@@ -9,6 +9,7 @@ import contextlib
 
 import zigpy.zdo
 import zigpy.util
+import zigpy.state
 import zigpy.types
 import zigpy.config
 import zigpy.device
@@ -135,12 +136,12 @@ class ControllerApplication(zigpy.application.ControllerApplication):
     @property
     def network_key(self) -> t.KeyData | None:
         # This is not a standard Zigpy property
-        return self._network_key
+        return self.state.network_information.network_key.key
 
     @property
     def network_key_seq(self) -> t.uint8_t | None:
         # This is not a standard Zigpy property
-        return self._network_key_seq
+        return self.state.network_information.network_key.seq
 
     @classmethod
     async def probe(cls, device_config: conf.ConfigType) -> bool:
@@ -1279,15 +1280,22 @@ class ControllerApplication(zigpy.application.ControllerApplication):
 
         await self._znp.load_network_info()
 
-        self._ieee = self._znp.network_info.ieee
-        self._nwk = self._znp.network_info.nwk
-        self._channel = self._znp.network_info.channel
-        self._channels = self._znp.network_info.channels
-        self._pan_id = self._znp.network_info.pan_id
-        self._ext_pan_id = self._znp.network_info.extended_pan_id
-        self._nwk_update_id = self._znp.network_info.nwk_update_id
-        self._network_key = self._znp.network_info.network_key
-        self._network_key_seq = self._znp.network_info.network_key_seq
+        self.ieee = self._znp.network_info.ieee
+        self.nwk = self._znp.network_info.nwk
+        self.state.network_information.channel = self._znp.network_info.channel
+        self.state.network_information.channel_mask = self._znp.network_info.channels
+        self.state.network_information.pan_id = self._znp.network_info.pan_id
+        self.state.network_information.extended_pan_id = (
+            self._znp.network_info.extended_pan_id
+        )
+        self.state.network_information.nwk_update_id = (
+            self._znp.network_info.nwk_update_id
+        )
+        nwk_key = zigpy.state.Key(
+            key=self._znp.network_info.network_key,
+            seq=self._znp.network_info.network_key_seq,
+        )
+        self.state.network_information.network_key = nwk_key
 
     def _find_endpoint(self, dst_ep: int, profile: int, cluster: int) -> int:
         """

--- a/zigpy_znp/zigbee/application.py
+++ b/zigpy_znp/zigbee/application.py
@@ -121,8 +121,6 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         self._watchdog_task = asyncio.Future()
         self._watchdog_task.cancel()
 
-        self._network_key = None
-        self._network_key_seq = None
         self._version_rsp = None
         self._concurrent_requests_semaphore = None
         self._currently_waiting_requests = 0
@@ -136,12 +134,16 @@ class ControllerApplication(zigpy.application.ControllerApplication):
     @property
     def network_key(self) -> t.KeyData | None:
         # This is not a standard Zigpy property
-        return self.state.network_information.network_key.key
+        if self.state.network_information.network_key:
+            return self.state.network_information.network_key.key
+        return None
 
     @property
     def network_key_seq(self) -> t.uint8_t | None:
         # This is not a standard Zigpy property
-        return self.state.network_information.network_key.seq
+        if self.state.network_information.network_key:
+            return self.state.network_information.network_key.seq
+        return None
 
     @classmethod
     async def probe(cls, device_config: conf.ConfigType) -> bool:


### PR DESCRIPTION
Syncup with zigpy==0.37.0 changes and use `zigpy.state` container to store network information. 