### PR TITLE
Add "not recommended" note to CC2530 and C2531

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ USB-adapters, GPIO-modules, and development-boards flashed with TI's Z-Stack are
  - CC2652P/CC2652R/CC2652RB USB stick and dev board hardware
  - CC1352P/CC1352R USB stick and dev board hardware
  - CC2538 + CC2592 dev board hardware
- - CC2531 USB stick hardware
- - CC2530 + CC2591/CC2592 USB stick hardware
+ - CC2531 USB stick hardware (not recommended for Zigbee networks with more than 20 devices)
+ - CC2530 + CC2591/CC2592 USB stick hardware (not recommended for Zigbee networks with more than 20 devices)
 
 Tip! Adapters listed as "[Texas Instruments sticks compatible with Zigbee2MQTT](https://www.zigbee2mqtt.io/information/supported_adapters)" also works with zigpy-znp.
 


### PR DESCRIPTION
Add a "_**not recommended for Zigbee networks with more than 20 devices**_" note to both CC2530 and C2531 in README.md

ZHA / zigpy developers elected to not whitelist "TI CC2531" USB adapter ZHA discovery due to its older less powerful hardware:

https://github.com/home-assistant/core/pull/55298

Zigbee2MQTT as well added "not recommended" notes to both CC2530 and CC2531 in their official supported adapters list:

https://www.zigbee2mqtt.io/information/supported_adapters

 - _Texas Instruments CC2531 (**not recommended**)_
 - _Texas Instruments CC2530 (**not recommended**)_

https://www.zigbee2mqtt.io/information/supported_adapters#notes

_Adapters based on the CC2530 or CC2531 chip are not powerful and not recommended for networks larger than 20 devices._

Also, Zigbee2MQTT / zigbee-herdsman developer Koenkk noted Z-Stack 3.0.x firmware is not recommended on C2530/C2531:

https://github.com/Koenkk/Z-Stack-firmware/tree/master/coordinator#im-using-a-cc2530-or-cc2531-which-firmware-should-i-use

### _I'm using a CC2530 or CC2531, which firmware should I use?_
_This depends:_
- _Zigbee 3.0 firmwares are **not** recommended for the CC2530 and CC2531 (since those are not powerful enough)_
- _If you have a network of 1 - 15 devices, the Z-Stack_Home_1.2 **default** firmware is recommended._
- _If you have a network of 15+ devices, the Z-Stack_Home_1.2 **source routing** firmware is recommended._
- _Note that the **source routing** firmware only supports 5 direct children, therefore you need to have routers in range of the coordinator._

