### PR TITLE
Update README.md all CC253x are not recommended

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,9 @@ USB-adapters, GPIO-modules, and development-boards flashed with TI's Z-Stack are
 
  - CC2652P/CC2652R/CC2652RB USB stick and dev board hardware
  - CC1352P/CC1352R USB stick and dev board hardware
- - CC2538 + CC2592 USB stick and dev board hardware (not recommended since use older hardware and firmware)
- - CC2531 USB stick hardware (not recommended for Zigbee networks with more than 20 devices)
- - CC2530 + CC2591/CC2592 USB stick hardware (not recommended for Zigbee networks with more than 20 devices)
+ - CC2538 + CC2592 USB stick and dev board hardware (**not recommended, old hardware and end-of-life firmware**)
+ - CC2531 USB stick hardware (**not recommended for Zigbee networks with more than 20 devices**)
+ - CC2530 + CC2591/CC2592 USB stick hardware (**not recommended for Zigbee networks with more than 20 devices**)
 
 Tip! Adapters listed as "[Texas Instruments sticks compatible with Zigbee2MQTT](https://www.zigbee2mqtt.io/information/supported_adapters)" also works with zigpy-znp.
 
@@ -112,7 +112,6 @@ These specific adapters are used as reference hardware for development and testi
 
  - [TI LAUNCHXL-CC26X2R1](https://www.ti.com/tool/LAUNCHXL-CC26X2R1) running [Z-Stack 3 firmware (based on version 4.40.00.44)](https://github.com/Koenkk/Z-Stack-firmware/tree/master/coordinator/Z-Stack_3.x.0/bin). You can flash `CC2652R_20210120.hex` using [TI's UNIFLASH](https://www.ti.com/tool/download/UNIFLASH).
  - [Electrolama zzh CC2652R](https://electrolama.com/projects/zig-a-zig-ah/) and [Slaesh CC2652R](https://slae.sh/projects/cc2652/) sticks running [Z-Stack 3 firmware (based on version 4.40.00.44)](https://github.com/Koenkk/Z-Stack-firmware/tree/master/coordinator/Z-Stack_3.x.0/bin). You can flash `CC2652R_20210120.hex` or `CC2652RB_20210120.hex` respectively using [cc2538-bsl](https://github.com/JelmerT/cc2538-bsl).
- - CC2531 running [Z-Stack 3.0.1](https://github.com/Koenkk/Z-Stack-firmware/blob/master/coordinator/Z-Stack_3.0.x/bin/CC2531_20190425.zip). You can flash `CC2531ZNP-without-SBL.bin` to your stick directly with `zigpy_znp`: `python -m zigpy_znp.tools.flash_write -i /path/to/CC2531ZNP-without-SBL.bin /dev/serial/by-id/YOUR-CC2531` if your stick already has a serial bootloader. Note that Z-Stack 3.0.x firmware is not recommended for the CC2530 and CC2531 in a "production" environment (since they are not powerful enough).
  - CC2531 running [Z-Stack Home 1.2](https://github.com/Koenkk/Z-Stack-firmware/blob/master/coordinator/Z-Stack_Home_1.2/bin/default/CC2531_DEFAULT_20190608.zip). You can flash `CC2531ZNP-Prod.bin` to your stick directly with `zigpy_znp`: `python -m zigpy_znp.tools.flash_write -i /path/to/CC2531ZNP-Prod.bin /dev/serial/by-id/YOUR-CC2531` if your stick already has a serial bootloader.
 
 ## Texas Instruments Chip Part Numbers

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ USB-adapters, GPIO-modules, and development-boards flashed with TI's Z-Stack are
 
  - CC2652P/CC2652R/CC2652RB USB stick and dev board hardware
  - CC1352P/CC1352R USB stick and dev board hardware
- - CC2538 + CC2592 dev board hardware
+ - CC2538 + CC2592 USB stick and dev board hardware (not recommended since use older hardware and firmware)
  - CC2531 USB stick hardware (not recommended for Zigbee networks with more than 20 devices)
  - CC2530 + CC2591/CC2592 USB stick hardware (not recommended for Zigbee networks with more than 20 devices)
 
@@ -112,7 +112,7 @@ These specific adapters are used as reference hardware for development and testi
 
  - [TI LAUNCHXL-CC26X2R1](https://www.ti.com/tool/LAUNCHXL-CC26X2R1) running [Z-Stack 3 firmware (based on version 4.40.00.44)](https://github.com/Koenkk/Z-Stack-firmware/tree/master/coordinator/Z-Stack_3.x.0/bin). You can flash `CC2652R_20210120.hex` using [TI's UNIFLASH](https://www.ti.com/tool/download/UNIFLASH).
  - [Electrolama zzh CC2652R](https://electrolama.com/projects/zig-a-zig-ah/) and [Slaesh CC2652R](https://slae.sh/projects/cc2652/) sticks running [Z-Stack 3 firmware (based on version 4.40.00.44)](https://github.com/Koenkk/Z-Stack-firmware/tree/master/coordinator/Z-Stack_3.x.0/bin). You can flash `CC2652R_20210120.hex` or `CC2652RB_20210120.hex` respectively using [cc2538-bsl](https://github.com/JelmerT/cc2538-bsl).
- - CC2531 running [Z-Stack 3.0.1](https://github.com/Koenkk/Z-Stack-firmware/blob/master/coordinator/Z-Stack_3.0.x/bin/CC2531_20190425.zip). You can flash `CC2531ZNP-without-SBL.bin` to your stick directly with `zigpy_znp`: `python -m zigpy_znp.tools.flash_write -i /path/to/CC2531ZNP-without-SBL.bin /dev/serial/by-id/YOUR-CC2531` if your stick already has a serial bootloader.
+ - CC2531 running [Z-Stack 3.0.1](https://github.com/Koenkk/Z-Stack-firmware/blob/master/coordinator/Z-Stack_3.0.x/bin/CC2531_20190425.zip). You can flash `CC2531ZNP-without-SBL.bin` to your stick directly with `zigpy_znp`: `python -m zigpy_znp.tools.flash_write -i /path/to/CC2531ZNP-without-SBL.bin /dev/serial/by-id/YOUR-CC2531` if your stick already has a serial bootloader. Note that Z-Stack 3.0.x firmware is not recommended for the CC2530 and CC2531 in a "production" environment (since they are not powerful enough).
  - CC2531 running [Z-Stack Home 1.2](https://github.com/Koenkk/Z-Stack-firmware/blob/master/coordinator/Z-Stack_Home_1.2/bin/default/CC2531_DEFAULT_20190608.zip). You can flash `CC2531ZNP-Prod.bin` to your stick directly with `zigpy_znp`: `python -m zigpy_znp.tools.flash_write -i /path/to/CC2531ZNP-Prod.bin /dev/serial/by-id/YOUR-CC2531` if your stick already has a serial bootloader.
 
 ## Texas Instruments Chip Part Numbers


### PR DESCRIPTION
List CC2538 as not recommended and add a note that Z-Stack 3.0.x firmware is not recommended for the CC2530 and CC2531 in a "production" environment (since they are not powerful enough).

The argument is that while CC2538 based Zigbee coordinator adapters works they are no longer recommended by the Zigbee2MQTT community since they use outdated chips and older firmware.  Availability of CC2538 USB adapters are scarce and I also understand that no zigpy devs are using it as Zigbee coordinator reference hardware so not being well tested, (even though CC2538 should work as CC2530 and CC2531 in theory). Thus might be a good idea for zigpy-znp to also just list CC2538 as "not recommended" in favour of newer CC26x2 and CC13x2 based adapters instead so hopefully less new users buy old hardware as their their first Zigbee coordinator. puddly also posted this comment in https://github.com/zigpy/zigpy-znp/issues/48 about CC2538 around a year ago "*The last Z-Stack update for it was released more than two years ago and it will not support the newer route discovery features that improve network stability because the version of Z-Stack that it's stuck with supposedly has glitches.*"

Other references:

https://www.zigbee2mqtt.io/guide/adapters/#not-recommended

https://github.com/Koenkk/Z-Stack-firmware/blob/master/coordinator/

https://github.com/Koenkk/Z-Stack-firmware/tree/master/coordinator#im-using-a-cc2530-or-cc2531-which-firmware-should-i-use