### PR TITLE
Use ZDO converter for `Mgmt_NWK_Update_req`

### DIFF
--- a/zigpy_znp/zigbee/zdo_converters.py
+++ b/zigpy_znp/zigbee/zdo_converters.py
@@ -111,7 +111,7 @@ ZDO_CONVERTERS = {
                 ScanDuration=NwkUpdate.ScanDuration,
                 ScanCount=NwkUpdate.ScanCount,
                 # XXX: nwkUpdateId is hard-coded to `_NIB.nwkUpdateId + 1`
-                NwkManagerAddr=NwkUpdate.nwkManagerAddr,
+                NwkManagerAddr=NwkUpdate.nwkManagerAddr or 0x0000,
             )
         ),
         (

--- a/zigpy_znp/zigbee/zdo_converters.py
+++ b/zigpy_znp/zigbee/zdo_converters.py
@@ -102,6 +102,36 @@ ZDO_CONVERTERS = {
         (lambda addr: c.ZDO.MgmtLeaveRsp.Callback(partial=True, Src=addr.address)),
         (lambda rsp: (ZDOCmd.Mgmt_Leave_rsp, {"Status": rsp.Status})),
     ),
+    ZDOCmd.Mgmt_NWK_Update_req: (
+        (
+            lambda addr, NwkUpdate: c.ZDO.MgmtNWKUpdateReq.Req(
+                Dst=addr.address,
+                DstAddrMode=addr.mode,
+                Channels=NwkUpdate.ScanChannels,
+                ScanDuration=NwkUpdate.ScanDuration,
+                ScanCount=NwkUpdate.ScanCount,
+                # XXX: nwkUpdateId is hard-coded to `_NIB.nwkUpdateId + 1`
+                NwkManagerAddr=NwkUpdate.nwkManagerAddr,
+            )
+        ),
+        (
+            lambda addr: c.ZDO.MgmtNWKUpdateNotify.Callback(
+                partial=True, Src=addr.address
+            )
+        ),
+        (
+            lambda rsp: (
+                ZDOCmd.Mgmt_NWK_Update_rsp,
+                {
+                    "Status": rsp.Status,
+                    "ScannedChannels": rsp.ScannedChannels,
+                    "TotalTransmissions": rsp.TotalTransmissions,
+                    "TransmissionFailures": rsp.TransmissionFailures,
+                    "EnergyValues": rsp.EnergyValues,
+                },
+            )
+        ),
+    ),
     ZDOCmd.Bind_req: (
         (
             lambda addr, SrcAddress, SrcEndpoint, ClusterID, DstAddress: (


### PR DESCRIPTION
This decouples the zigpy-znp energy scan tool from the zigpy-znp API.  It will be moved into zigpy-cli in a future release.

 - Confirmed working with the Conbee II.
 - Does not work with bellows: the coordinator does not implement `Mgmt_NWK_Update_req`.

@Adminiuga Thoughts about making this work with bellows? How about a method in zigpy with a default implementation?

```python
class ControllerApplication:
    async def energy_scan(self, channels: t.Channels, duration_exp: int, count: int) -> list[int]:
        rsp = await self.get_device(nwk=0x0000).zdo.Mgmt_NWK_Update_req(
            zdo_t.NwkUpdate(
                ScanChannels=channels,
                ScanDuration=duration_exp,
                ScanCount=count,
            )
        )

        return rsp.EnergyValues
```

Bellows can then override it to use the appropriate EZSP command.