### PR TITLE
Connect multiple times on startup and speed up initial connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ zha:
 
       # Delay between auto-reconnect attempts in case the device gets disconnected
       auto_reconnect_retry_delay: 5
+
+      # Pin states for skipping the bootloader
+      connect_rts_pin_states: [off, on, off]
+      connect_dtr_pin_states: [off, off, off]
 ```
 
 # Tools

--- a/tests/api/test_connect.py
+++ b/tests/api/test_connect.py
@@ -9,8 +9,6 @@ from zigpy_znp.api import ZNP
 
 from ..conftest import BaseServerZNP, CoroutineMock, config_for_port_path
 
-pytestmark = [pytest.mark.asyncio]
-
 
 async def test_connect_no_test(make_znp_server):
     znp_server = make_znp_server(server_cls=BaseServerZNP)

--- a/tests/api/test_listeners.py
+++ b/tests/api/test_listeners.py
@@ -7,8 +7,6 @@ import zigpy_znp.types as t
 import zigpy_znp.commands as c
 from zigpy_znp.api import OneShotResponseListener, CallbackResponseListener
 
-pytestmark = [pytest.mark.asyncio]
-
 
 async def test_resolve(event_loop, mocker):
     callback = mocker.Mock()

--- a/tests/api/test_network_state.py
+++ b/tests/api/test_network_state.py
@@ -4,8 +4,6 @@ import pytest
 
 from ..conftest import ALL_DEVICES, FORMED_DEVICES, BaseZStack1CC2531
 
-pytestmark = [pytest.mark.asyncio]
-
 
 @pytest.mark.parametrize("to_device", ALL_DEVICES)
 @pytest.mark.parametrize("from_device", FORMED_DEVICES)

--- a/tests/api/test_nvram.py
+++ b/tests/api/test_nvram.py
@@ -5,8 +5,6 @@ import zigpy_znp.commands as c
 from zigpy_znp.types import nvids
 from zigpy_znp.exceptions import SecurityError
 
-pytestmark = [pytest.mark.asyncio]
-
 
 async def test_osal_writes_invalid(connected_znp):
     znp, _ = connected_znp

--- a/tests/api/test_request.py
+++ b/tests/api/test_request.py
@@ -10,8 +10,6 @@ import zigpy_znp.commands as c
 from zigpy_znp.frames import GeneralFrame
 from zigpy_znp.exceptions import CommandNotRecognized, InvalidCommandResponse
 
-pytestmark = [pytest.mark.asyncio]
-
 
 async def test_callback_rsp(connected_znp, event_loop):
     znp, znp_server = connected_znp

--- a/tests/api/test_request.py
+++ b/tests/api/test_request.py
@@ -52,19 +52,19 @@ async def test_cleanup_timeout_internal(connected_znp):
     znp._config[conf.CONF_ZNP_CONFIG][conf.CONF_SREQ_TIMEOUT] = 0.1
     znp._config[conf.CONF_ZNP_CONFIG][conf.CONF_ARSP_TIMEOUT] = 0.1
 
-    assert not znp._listeners
+    assert not any(znp._listeners.values())
 
     with pytest.raises(asyncio.TimeoutError):
         await znp.request(c.UTIL.TimeAlive.Req())
 
     # We should be cleaned up
-    assert not znp._listeners
+    assert not any(znp._listeners.values())
 
 
 async def test_cleanup_timeout_external(connected_znp):
     znp, znp_server = connected_znp
 
-    assert not znp._listeners
+    assert not any(znp._listeners.values())
 
     # This request will timeout because we didn't send anything back
     with pytest.raises(asyncio.TimeoutError):
@@ -72,13 +72,13 @@ async def test_cleanup_timeout_external(connected_znp):
             await znp.request(c.UTIL.TimeAlive.Req())
 
     # We should be cleaned up
-    assert not znp._listeners
+    assert not any(znp._listeners.values())
 
 
 async def test_callback_rsp_cleanup_timeout_external(connected_znp):
     znp, znp_server = connected_znp
 
-    assert not znp._listeners
+    assert not any(znp._listeners.values())
 
     # This request will timeout because we didn't send anything back
     with pytest.raises(asyncio.TimeoutError):
@@ -89,7 +89,7 @@ async def test_callback_rsp_cleanup_timeout_external(connected_znp):
             )
 
     # We should be cleaned up
-    assert not znp._listeners
+    assert not any(znp._listeners.values())
 
 
 @pytest.mark.parametrize("background", [False, True])
@@ -98,7 +98,7 @@ async def test_callback_rsp_cleanup_timeout_internal(background, connected_znp):
     znp._config[conf.CONF_ZNP_CONFIG][conf.CONF_SREQ_TIMEOUT] = 0.1
     znp._config[conf.CONF_ZNP_CONFIG][conf.CONF_ARSP_TIMEOUT] = 0.1
 
-    assert not znp._listeners
+    assert not any(znp._listeners.values())
 
     # This request will timeout because we didn't send anything back
     with pytest.raises(asyncio.TimeoutError):
@@ -109,7 +109,7 @@ async def test_callback_rsp_cleanup_timeout_internal(background, connected_znp):
         )
 
     # We should be cleaned up
-    assert not znp._listeners
+    assert not any(znp._listeners.values())
 
 
 async def test_callback_rsp_background_timeout(connected_znp, mocker):
@@ -146,7 +146,7 @@ async def test_callback_rsp_background_timeout(connected_znp, mocker):
     await reply
 
     # We should be cleaned up
-    assert not znp._listeners
+    assert not any(znp._listeners.values())
 
     # Command was properly handled
     assert len(znp._unhandled_command.mock_calls) == 0
@@ -157,7 +157,7 @@ async def test_callback_rsp_cleanup_concurrent(connected_znp, event_loop, mocker
 
     mocker.spy(znp, "_unhandled_command")
 
-    assert not znp._listeners
+    assert not any(znp._listeners.values())
 
     def send_responses():
         znp_server.send(c.UTIL.TimeAlive.Rsp(Seconds=123))
@@ -173,7 +173,7 @@ async def test_callback_rsp_cleanup_concurrent(connected_znp, event_loop, mocker
     )
 
     # We should be cleaned up
-    assert not znp._listeners
+    assert not any(znp._listeners.values())
 
     assert callback_rsp == c.SYS.OSALTimerExpired.Callback(Id=0xAB)
 

--- a/tests/api/test_response.py
+++ b/tests/api/test_response.py
@@ -13,11 +13,11 @@ pytestmark = [pytest.mark.asyncio]
 async def test_responses(connected_znp):
     znp, znp_server = connected_znp
 
-    assert not znp._listeners
+    assert not any(znp._listeners.values())
 
     future = znp.wait_for_response(c.SYS.Ping.Rsp(partial=True))
 
-    assert znp._listeners
+    assert any(znp._listeners.values())
 
     response = c.SYS.Ping.Rsp(Capabilities=t.MTCapabilities.SYS)
     znp_server.send(response)
@@ -26,13 +26,13 @@ async def test_responses(connected_znp):
 
     # Our listener will have been cleaned up after a step
     await asyncio.sleep(0)
-    assert not znp._listeners
+    assert not any(znp._listeners.values())
 
 
 async def test_responses_multiple(connected_znp):
     znp, _ = connected_znp
 
-    assert not znp._listeners
+    assert not any(znp._listeners.values())
 
     future1 = znp.wait_for_response(c.SYS.Ping.Rsp(partial=True))
     future2 = znp.wait_for_response(c.SYS.Ping.Rsp(partial=True))
@@ -49,7 +49,7 @@ async def test_responses_multiple(connected_znp):
     assert not future2.done()
     assert not future3.done()
 
-    assert znp._listeners
+    assert any(znp._listeners.values())
 
 
 async def test_response_timeouts(connected_znp):
@@ -68,7 +68,7 @@ async def test_response_timeouts(connected_znp):
 
     # The response was successfully received so we should have no outstanding listeners
     await asyncio.sleep(0)
-    assert not znp._listeners
+    assert not any(znp._listeners.values())
 
     asyncio.create_task(send_soon(0.6))
 
@@ -80,7 +80,7 @@ async def test_response_timeouts(connected_znp):
 
     # Our future still completed, albeit unsuccessfully.
     # We should have no leaked listeners here.
-    assert not znp._listeners
+    assert not any(znp._listeners.values())
 
 
 async def test_response_matching_partial(connected_znp):

--- a/tests/api/test_response.py
+++ b/tests/api/test_response.py
@@ -7,8 +7,6 @@ import zigpy_znp.types as t
 import zigpy_znp.commands as c
 from zigpy_znp.utils import deduplicate_commands
 
-pytestmark = [pytest.mark.asyncio]
-
 
 async def test_responses(connected_znp):
     znp, znp_server = connected_znp

--- a/tests/application/test_connect.py
+++ b/tests/application/test_connect.py
@@ -8,8 +8,6 @@ from zigpy_znp.zigbee.application import ControllerApplication
 
 from ..conftest import FORMED_DEVICES, FormedLaunchpadCC26X2R1, swap_attribute
 
-pytestmark = [pytest.mark.asyncio]
-
 
 async def test_no_double_connect(make_znp_server, mocker):
     znp_server = make_znp_server(server_cls=FormedLaunchpadCC26X2R1)

--- a/tests/application/test_connect.py
+++ b/tests/application/test_connect.py
@@ -60,7 +60,7 @@ async def test_probe_unsuccessful():
 
 @pytest.mark.parametrize("device", FORMED_DEVICES)
 async def test_probe_unsuccessful_slow(device, make_znp_server, mocker):
-    znp_server = make_znp_server(server_cls=device)
+    znp_server = make_znp_server(server_cls=device, shorten_delays=False)
 
     # Don't respond to anything
     znp_server._listeners.clear()
@@ -78,7 +78,7 @@ async def test_probe_unsuccessful_slow(device, make_znp_server, mocker):
 
 @pytest.mark.parametrize("device", FORMED_DEVICES)
 async def test_probe_successful(device, make_znp_server):
-    znp_server = make_znp_server(server_cls=device)
+    znp_server = make_znp_server(server_cls=device, shorten_delays=False)
 
     assert await ControllerApplication.probe(
         conf.SCHEMA_DEVICE({conf.CONF_DEVICE_PATH: znp_server.serial_port})
@@ -89,7 +89,7 @@ async def test_probe_successful(device, make_znp_server):
 @pytest.mark.parametrize("device", FORMED_DEVICES)
 async def test_probe_multiple(device, make_znp_server):
     # Make sure that our listeners don't get cleaned up after each probe
-    znp_server = make_znp_server(server_cls=device)
+    znp_server = make_znp_server(server_cls=device, shorten_delays=False)
     znp_server.close = lambda: None
 
     config = conf.SCHEMA_DEVICE({conf.CONF_DEVICE_PATH: znp_server.serial_port})
@@ -112,6 +112,7 @@ async def test_reconnect(device, event_loop, make_application):
                 conf.CONF_SREQ_TIMEOUT: 0.1,
             }
         },
+        shorten_delays=False,
     )
 
     # Start up the server

--- a/tests/application/test_joining.py
+++ b/tests/application/test_joining.py
@@ -16,8 +16,6 @@ from ..conftest import (
     FormedLaunchpadCC26X2R1,
 )
 
-pytestmark = [pytest.mark.asyncio]
-
 
 @pytest.mark.parametrize(
     "device,fixed_joining_bug",

--- a/tests/application/test_nvram_migration.py
+++ b/tests/application/test_nvram_migration.py
@@ -7,8 +7,6 @@ from zigpy_znp.types.nvids import ExNvIds, OsalNvIds
 
 from ..conftest import FORMED_DEVICES, FormedZStack3CC2531
 
-pytestmark = [pytest.mark.asyncio]
-
 
 @pytest.mark.parametrize("device", FORMED_DEVICES)
 async def test_addrmgr_empty_entries(make_connected_znp, device):

--- a/tests/application/test_requests.py
+++ b/tests/application/test_requests.py
@@ -13,8 +13,6 @@ from zigpy_znp.exceptions import InvalidCommandResponse
 
 from ..conftest import FORMED_DEVICES, CoroutineMock, FormedLaunchpadCC26X2R1
 
-pytestmark = [pytest.mark.asyncio]
-
 
 @pytest.mark.parametrize("device", FORMED_DEVICES)
 async def test_zdo_request_interception(device, make_application):

--- a/tests/application/test_startup.py
+++ b/tests/application/test_startup.py
@@ -18,8 +18,6 @@ from ..conftest import (
     FormedLaunchpadCC26X2R1,
 )
 
-pytestmark = [pytest.mark.asyncio]
-
 DEV_NETWORK_SETTINGS = {
     FormedLaunchpadCC26X2R1: (
         "CC1352/CC2652, Z-Stack 3.30+ (build 20200805)",

--- a/tests/application/test_zigpy_callbacks.py
+++ b/tests/application/test_zigpy_callbacks.py
@@ -9,8 +9,6 @@ import zigpy_znp.commands as c
 
 from ..conftest import FORMED_DEVICES, CoroutineMock
 
-pytestmark = [pytest.mark.asyncio]
-
 
 def awaitable_mock(return_value):
     mock_called = asyncio.get_running_loop().create_future()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,16 @@ LOGGER = logging.getLogger(__name__)
 FAKE_SERIAL_PORT = "/dev/ttyFAKE0"
 
 
+# Globally handle async tests and error on unawaited coroutines
+def pytest_collection_modifyitems(session, config, items):
+    for item in items:
+        item.add_marker(
+            pytest.mark.filterwarnings("error::pytest.PytestUnraisableExceptionWarning")
+        )
+        item.add_marker(pytest.mark.filterwarnings("error::RuntimeWarning"))
+        item.add_marker(pytest.mark.asyncio)
+
+
 class ForwardingSerialTransport:
     """
     Serial transport that hooks directly into a protocol

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,9 @@
 import enum
 
-from zigpy_znp.config import EnumValue
+import pytest
+from voluptuous import Invalid
+
+import zigpy_znp.config as conf
 
 
 def test_EnumValue():
@@ -8,15 +11,65 @@ def test_EnumValue():
         foo = 123
         BAR = 456
 
-    assert EnumValue(TestEnum)("foo") == TestEnum.foo
-    assert EnumValue(TestEnum)("BAR") == TestEnum.BAR
+    assert conf.EnumValue(TestEnum)("foo") == TestEnum.foo
+    assert conf.EnumValue(TestEnum)("BAR") == TestEnum.BAR
 
-    assert (
-        EnumValue(TestEnum, transformer=lambda s: str(s).lower())("FOO") == TestEnum.foo
-    )
-    assert (
-        EnumValue(TestEnum, transformer=lambda s: str(s).upper())("bar") == TestEnum.BAR
+    assert conf.EnumValue(TestEnum, transformer=str.lower)("FOO") == TestEnum.foo
+    assert conf.EnumValue(TestEnum, transformer=str.upper)("bar") == TestEnum.BAR
+
+    assert conf.EnumValue(TestEnum)(TestEnum.foo) == TestEnum.foo
+    assert conf.EnumValue(TestEnum)(TestEnum.BAR) == TestEnum.BAR
+
+
+def test_pin_states_same_lengths():
+    # Bare schema works
+    conf.CONFIG_SCHEMA(
+        {
+            conf.CONF_DEVICE: {conf.CONF_DEVICE_PATH: "/dev/null"},
+            conf.CONF_ZNP_CONFIG: {},
+        }
     )
 
-    assert EnumValue(TestEnum)(TestEnum.foo) == TestEnum.foo
-    assert EnumValue(TestEnum)(TestEnum.BAR) == TestEnum.BAR
+    # So does one with explicitly specified pin states
+    config = conf.CONFIG_SCHEMA(
+        {
+            conf.CONF_DEVICE: {conf.CONF_DEVICE_PATH: "/dev/null"},
+            conf.CONF_ZNP_CONFIG: {
+                conf.CONF_CONNECT_RTS_STATES: ["on", True, 0, 0, 0, 1, 1],
+                conf.CONF_CONNECT_DTR_STATES: ["off", False, 1, 0, 0, 1, 1],
+            },
+        }
+    )
+
+    assert config[conf.CONF_ZNP_CONFIG][conf.CONF_CONNECT_RTS_STATES] == [
+        True,
+        True,
+        False,
+        False,
+        False,
+        True,
+        True,
+    ]
+    assert config[conf.CONF_ZNP_CONFIG][conf.CONF_CONNECT_DTR_STATES] == [
+        False,
+        False,
+        True,
+        False,
+        False,
+        True,
+        True,
+    ]
+
+
+def test_pin_states_different_lengths():
+    # They must be the same length
+    with pytest.raises(Invalid):
+        conf.CONFIG_SCHEMA(
+            {
+                conf.CONF_DEVICE: {conf.CONF_DEVICE_PATH: "/dev/null"},
+                conf.CONF_ZNP_CONFIG: {
+                    conf.CONF_CONNECT_RTS_STATES: [1, 1, 0],
+                    conf.CONF_CONNECT_DTR_STATES: [1, 1],
+                },
+            }
+        )

--- a/tests/test_uart.py
+++ b/tests/test_uart.py
@@ -230,7 +230,7 @@ async def test_connection_lost(dummy_serial_conn, mocker, event_loop):
     znp.connection_lost = conn_lost_fut.set_result
 
     protocol = await znp_uart.connect(
-        conf.SCHEMA_DEVICE({conf.CONF_DEVICE_PATH: device}), api=znp, toggle_rts=False
+        conf.SCHEMA_DEVICE({conf.CONF_DEVICE_PATH: device}), api=znp
     )
 
     exception = RuntimeError("Uh oh, something broke")
@@ -245,50 +245,6 @@ async def test_connection_made(dummy_serial_conn, mocker):
     device, _ = dummy_serial_conn
     znp = mocker.Mock()
 
-    await znp_uart.connect(
-        conf.SCHEMA_DEVICE({conf.CONF_DEVICE_PATH: device}), api=znp, toggle_rts=False
-    )
+    await znp_uart.connect(conf.SCHEMA_DEVICE({conf.CONF_DEVICE_PATH: device}), api=znp)
 
     znp.connection_made.assert_called_once_with()
-
-
-@pytest.mark.asyncio
-async def test_no_toggle_rts(dummy_serial_conn, mocker):
-    device, serial = dummy_serial_conn
-
-    type(serial).dtr = dtr = mocker.PropertyMock()
-    type(serial).rts = rts = mocker.PropertyMock()
-
-    znp = mocker.Mock()
-
-    await znp_uart.connect(
-        conf.SCHEMA_DEVICE({conf.CONF_DEVICE_PATH: device}), api=znp, toggle_rts=False
-    )
-
-    assert dtr.mock_calls == []
-    assert rts.mock_calls == []
-
-
-@pytest.mark.asyncio
-async def test_toggle_rts(dummy_serial_conn, mocker):
-    device, serial = dummy_serial_conn
-
-    type(serial).dtr = dtr = mocker.PropertyMock()
-    type(serial).rts = rts = mocker.PropertyMock()
-
-    znp = mocker.Mock()
-
-    await znp_uart.connect(
-        conf.SCHEMA_DEVICE({conf.CONF_DEVICE_PATH: device}), api=znp, toggle_rts=True
-    )
-
-    assert dtr.mock_calls == [
-        mocker.call(False),
-        mocker.call(False),
-        mocker.call(False),
-    ]
-    assert rts.mock_calls == [
-        mocker.call(False),
-        mocker.call(True),
-        mocker.call(False),
-    ]

--- a/tests/test_uart.py
+++ b/tests/test_uart.py
@@ -221,7 +221,6 @@ def test_uart_frame_received_error(connected_uart, mocker):
     znp.frame_received.call_count == 3
 
 
-@pytest.mark.asyncio
 async def test_connection_lost(dummy_serial_conn, mocker, event_loop):
     device, _ = dummy_serial_conn
 
@@ -240,7 +239,6 @@ async def test_connection_lost(dummy_serial_conn, mocker, event_loop):
     assert (await conn_lost_fut) == exception
 
 
-@pytest.mark.asyncio
 async def test_connection_made(dummy_serial_conn, mocker):
     device, _ = dummy_serial_conn
     znp = mocker.Mock()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -63,7 +63,6 @@ def test_command_deduplication_complex():
     }
 
 
-@pytest.mark.asyncio
 async def test_combine_concurrent_calls():
     class TestFuncs:
         def __init__(self):

--- a/tests/tools/test_energy_scan.py
+++ b/tests/tools/test_energy_scan.py
@@ -9,7 +9,6 @@ from zigpy_znp.tools.energy_scan import main as energy_scan
 from ..conftest import EMPTY_DEVICES, FORMED_DEVICES
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("device", EMPTY_DEVICES)
 async def test_energy_scan_unformed(device, make_znp_server, caplog):
     znp_server = make_znp_server(server_cls=device)
@@ -18,7 +17,6 @@ async def test_energy_scan_unformed(device, make_znp_server, caplog):
     assert "Form a network" in caplog.text
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("device", FORMED_DEVICES)
 async def test_energy_scan_formed(device, make_znp_server, capsys):
     znp_server = make_znp_server(server_cls=device)

--- a/tests/tools/test_flash.py
+++ b/tests/tools/test_flash.py
@@ -9,9 +9,6 @@ from zigpy_znp.tools.flash_write import main as flash_write, get_firmware_crcs
 
 from ..conftest import BaseServerZNP, CoroutineMock
 
-pytestmark = [pytest.mark.asyncio]
-
-
 random.seed(12345)
 FAKE_IMAGE_SIZE = 2 ** 10
 FAKE_FLASH = bytearray(

--- a/tests/tools/test_form_network.py
+++ b/tests/tools/test_form_network.py
@@ -6,7 +6,6 @@ from zigpy_znp.tools.form_network import main as form_network
 from ..conftest import ALL_DEVICES, EMPTY_DEVICES
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("device", ALL_DEVICES)
 async def test_form_network(device, make_znp_server):
     znp_server = make_znp_server(server_cls=device)

--- a/tests/tools/test_network_backup_restore.py
+++ b/tests/tools/test_network_backup_restore.py
@@ -135,7 +135,6 @@ def test_schema_validation_device_key_info(backup_json):
 
 
 @pytest.mark.parametrize("device", EMPTY_DEVICES)
-@pytest.mark.asyncio
 async def test_network_backup_empty(device, make_znp_server):
     znp_server = make_znp_server(server_cls=device)
 
@@ -144,7 +143,6 @@ async def test_network_backup_empty(device, make_znp_server):
 
 
 @pytest.mark.parametrize("device", [FormedZStack1CC2531])
-@pytest.mark.asyncio
 async def test_network_backup_pipe(device, make_znp_server, capsys):
     znp_server = make_znp_server(server_cls=device)
 
@@ -155,7 +153,6 @@ async def test_network_backup_pipe(device, make_znp_server, capsys):
 
 
 @pytest.mark.parametrize("device", FORMED_DEVICES)
-@pytest.mark.asyncio
 async def test_network_backup_formed(device, make_znp_server, tmp_path):
     znp_server = make_znp_server(server_cls=device)
 
@@ -192,7 +189,6 @@ async def test_network_backup_formed(device, make_znp_server, tmp_path):
 
 
 @pytest.mark.parametrize("device", ALL_DEVICES)
-@pytest.mark.asyncio
 async def test_network_restore_and_backup(
     device, make_znp_server, backup_json, tmp_path
 ):
@@ -230,7 +226,6 @@ async def test_network_restore_and_backup(
 
 
 @pytest.mark.parametrize("device", [ResetLaunchpadCC26X2R1])
-@pytest.mark.asyncio
 async def test_network_restore_pick_optimal_tclk(
     device, make_znp_server, backup_json, tmp_path
 ):
@@ -254,7 +249,6 @@ async def test_network_restore_pick_optimal_tclk(
     assert backup_json2["stack_specific"]["zstack"]["tclk_seed"] == old_tclk_seed
 
 
-@pytest.mark.asyncio
 async def test_tc_frame_counter_zstack1(make_connected_znp):
     znp, znp_server = await make_connected_znp(BaseZStack1CC2531)
     znp_server._nvram[ExNvIds.LEGACY] = {
@@ -267,7 +261,6 @@ async def test_tc_frame_counter_zstack1(make_connected_znp):
     assert (await security.read_tc_frame_counter(znp)) == 0xAABBCCDD
 
 
-@pytest.mark.asyncio
 async def test_tc_frame_counter_zstack30(make_connected_znp):
     znp, znp_server = await make_connected_znp(BaseZStack3CC2531)
     znp.network_info = BARE_NETWORK_INFO
@@ -299,7 +292,6 @@ async def test_tc_frame_counter_zstack30(make_connected_znp):
     assert (await security.read_tc_frame_counter(znp)) == 0xAABBCCDD
 
 
-@pytest.mark.asyncio
 async def test_tc_frame_counter_zstack33(make_connected_znp):
     znp, znp_server = await make_connected_znp(BaseLaunchpadCC26X2R1)
     znp.network_info = BARE_NETWORK_INFO

--- a/tests/tools/test_network_scan.py
+++ b/tests/tools/test_network_scan.py
@@ -8,8 +8,6 @@ from zigpy_znp.tools.network_scan import main as network_scan
 
 from ..conftest import FormedZStack1CC2531, FormedLaunchpadCC26X2R1
 
-pytestmark = [pytest.mark.asyncio]
-
 
 @pytest.mark.parametrize("device", [FormedLaunchpadCC26X2R1])
 async def test_network_scan(device, make_znp_server, capsys):

--- a/tests/tools/test_nvram.py
+++ b/tests/tools/test_nvram.py
@@ -12,8 +12,6 @@ from zigpy_znp.tools.nvram_write import main as nvram_write
 
 from ..conftest import ALL_DEVICES, BaseZStack1CC2531, FormedLaunchpadCC26X2R1
 
-pytestmark = [pytest.mark.asyncio]
-
 
 def dump_nvram(znp):
     obj = {}

--- a/zigpy_znp/config.py
+++ b/zigpy_znp/config.py
@@ -48,6 +48,20 @@ def EnumValue(enum, transformer=str):
     return validator
 
 
+def keys_have_same_length(*keys):
+    def validator(config):
+        lengths = [len(config[k]) for k in keys]
+
+        if len(set(lengths)) != 1:
+            raise vol.Invalid(
+                f"Values for {keys} must all have the same length: {lengths}"
+            )
+
+        return config
+
+    return validator
+
+
 CONF_ZNP_CONFIG = "znp_config"
 CONF_TX_POWER = "tx_power"
 CONF_LED_MODE = "led_mode"
@@ -56,6 +70,8 @@ CONF_SREQ_TIMEOUT = "sync_request_timeout"
 CONF_ARSP_TIMEOUT = "async_response_timeout"
 CONF_AUTO_RECONNECT_RETRY_DELAY = "auto_reconnect_retry_delay"
 CONF_MAX_CONCURRENT_REQUESTS = "max_concurrent_requests"
+CONF_CONNECT_RTS_STATES = "connect_rts_pin_states"
+CONF_CONNECT_DTR_STATES = "connect_dtr_pin_states"
 
 CONFIG_SCHEMA = CONFIG_SCHEMA.extend(
     {
@@ -77,7 +93,14 @@ CONFIG_SCHEMA = CONFIG_SCHEMA.extend(
                 vol.Optional(CONF_MAX_CONCURRENT_REQUESTS, default="auto"): vol.Any(
                     "auto", VolPositiveNumber
                 ),
-            }
+                vol.Optional(
+                    CONF_CONNECT_RTS_STATES, default=[False, True, False]
+                ): vol.Schema([cv_boolean]),
+                vol.Optional(
+                    CONF_CONNECT_DTR_STATES, default=[False, False, False]
+                ): vol.Schema([cv_boolean]),
+            },
+            keys_have_same_length(CONF_CONNECT_RTS_STATES, CONF_CONNECT_DTR_STATES),
         ),
     }
 )

--- a/zigpy_znp/config.py
+++ b/zigpy_znp/config.py
@@ -77,30 +77,32 @@ CONFIG_SCHEMA = CONFIG_SCHEMA.extend(
     {
         vol.Required(CONF_DEVICE): SCHEMA_DEVICE,
         vol.Optional(CONF_ZNP_CONFIG, default={}): vol.Schema(
-            {
-                vol.Optional(CONF_TX_POWER, default=None): vol.Any(
-                    None, vol.All(int, vol.Range(min=-22, max=22))
-                ),
-                vol.Optional(CONF_SREQ_TIMEOUT, default=15): VolPositiveNumber,
-                vol.Optional(CONF_ARSP_TIMEOUT, default=30): VolPositiveNumber,
-                vol.Optional(
-                    CONF_AUTO_RECONNECT_RETRY_DELAY, default=5
-                ): VolPositiveNumber,
-                vol.Optional(CONF_SKIP_BOOTLOADER, default=True): cv_boolean,
-                vol.Optional(CONF_LED_MODE, default=LEDMode.OFF): vol.Any(
-                    None, EnumValue(LEDMode, lambda v: str(v).upper())
-                ),
-                vol.Optional(CONF_MAX_CONCURRENT_REQUESTS, default="auto"): vol.Any(
-                    "auto", VolPositiveNumber
-                ),
-                vol.Optional(
-                    CONF_CONNECT_RTS_STATES, default=[False, True, False]
-                ): vol.Schema([cv_boolean]),
-                vol.Optional(
-                    CONF_CONNECT_DTR_STATES, default=[False, False, False]
-                ): vol.Schema([cv_boolean]),
-            },
-            keys_have_same_length(CONF_CONNECT_RTS_STATES, CONF_CONNECT_DTR_STATES),
+            vol.All(
+                {
+                    vol.Optional(CONF_TX_POWER, default=None): vol.Any(
+                        None, vol.All(int, vol.Range(min=-22, max=22))
+                    ),
+                    vol.Optional(CONF_SREQ_TIMEOUT, default=15): VolPositiveNumber,
+                    vol.Optional(CONF_ARSP_TIMEOUT, default=30): VolPositiveNumber,
+                    vol.Optional(
+                        CONF_AUTO_RECONNECT_RETRY_DELAY, default=5
+                    ): VolPositiveNumber,
+                    vol.Optional(CONF_SKIP_BOOTLOADER, default=True): cv_boolean,
+                    vol.Optional(CONF_LED_MODE, default=LEDMode.OFF): vol.Any(
+                        None, EnumValue(LEDMode, lambda v: str(v).upper())
+                    ),
+                    vol.Optional(CONF_MAX_CONCURRENT_REQUESTS, default="auto"): vol.Any(
+                        "auto", VolPositiveNumber
+                    ),
+                    vol.Optional(
+                        CONF_CONNECT_RTS_STATES, default=[False, True, False]
+                    ): vol.Schema([cv_boolean]),
+                    vol.Optional(
+                        CONF_CONNECT_DTR_STATES, default=[False, False, False]
+                    ): vol.Schema([cv_boolean]),
+                },
+                keys_have_same_length(CONF_CONNECT_RTS_STATES, CONF_CONNECT_DTR_STATES),
+            )
         ),
     }
 )

--- a/zigpy_znp/uart.py
+++ b/zigpy_znp/uart.py
@@ -98,6 +98,8 @@ class ZnpMtProtocol(asyncio.Protocol):
         self._transport.write(data)
 
     def set_dtr_rts(self, *, dtr: bool, rts: bool) -> None:
+        LOGGER.debug("Setting serial pin states: DTR=%s, RTS=%s", dtr, rts)
+
         self._transport.serial.dtr = dtr
         self._transport.serial.rts = rts
 

--- a/zigpy_znp/utils.py
+++ b/zigpy_znp/utils.py
@@ -153,6 +153,17 @@ class CallbackResponseListener(BaseResponseListener):
         return False
 
 
+class CatchAllResponse:
+    """
+    Response-like object that matches every request.
+    """
+
+    header = object()  # sentinel
+
+    def matches(self, other) -> bool:
+        return True
+
+
 def combine_concurrent_calls(function):
     """
     Decorator that allows concurrent calls to expensive coroutines to share a result.


### PR DESCRIPTION
Instead of just sending the bootloader skip bytes and connecting a single time, zigpy-znp now connects multiple times (similar to the way Z2M currently does it):

1. First just connect to the serial port.
2. If that doesn't work, try sending the bootloader skip bytes and try again.
3. If that doesn't work, try toggling the RTS pin and try once more.

This increases the chances of a connection attempt succeeding significantly while still taking the same amount of time as before.

A side effect of this change (and the original motivation) is that the CC2530 with an external USB-serial adapter is now fully supported.

To support custom coordinator boards (e.g. where RTS or DTR is mapped to RST), the pin toggling behavior is now configurable as well.