### PR TITLE
Fix bootloader skip for Slaesh's stick

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,11 @@ Launch Home Assistant with the `--skip-pip` command line option to prevent zigpy
  - Add https://github.com/home-assistant/hassio-addons-development as an addon repository.
  - Install the "Custom deps deployment" addon.
  - Add the following to your `configuration.yaml` file:
-	```yaml
-	pypi:
-	  - git+https://github.com/zigpy/zigpy-znp/
-	```
+   ```yaml
+   apk: []
+   pypi:
+     - git+https://github.com/zigpy/zigpy-znp/
+	 ```
 
 # Configuration
 Below are the defaults with the top-level Home Assistant `zha:` key.

--- a/tests/api/test_connect.py
+++ b/tests/api/test_connect.py
@@ -102,17 +102,9 @@ async def test_connect_skip_bootloader_rts_dtr_pins(make_znp_server, mocker):
     mocker.patch.object(znp.nvram, "determine_alignment", new=CoroutineMock())
     mocker.patch.object(znp, "detect_zstack_version", new=CoroutineMock())
 
-    num_pings = 0
-
-    def ping_rsp(req):
-        nonlocal num_pings
-        num_pings += 1
-
-        if num_pings >= 3:
-            return c.SYS.Ping.Rsp(Capabilities=t.MTCapabilities.SYS)
-
-    # Ignore the first few pings so we trigger the pin toggling
-    znp_server.reply_to(c.SYS.Ping.Req(), responses=ping_rsp)
+    znp_server.reply_to(
+        c.SYS.Ping.Req(), responses=[c.SYS.Ping.Rsp(Capabilities=t.MTCapabilities.SYS)]
+    )
 
     await znp.connect(test_port=True)
 

--- a/zigpy_znp/zigbee/application.py
+++ b/zigpy_znp/zigbee/application.py
@@ -135,15 +135,15 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         LOGGER.debug("Probing %s", znp._port_path)
 
         try:
-            async with async_timeout.timeout(PROBE_TIMEOUT):
-                await znp.connect()
-
-            return True
+            # `ZNP.connect` times out on its own
+            await znp.connect()
         except Exception as e:
             LOGGER.debug(
                 "Failed to probe ZNP radio with config %s", device_config, exc_info=e
             )
             return False
+        else:
+            return True
         finally:
             znp.close()
 


### PR DESCRIPTION
Perform pin toggling before startup and extend timeout. Broken by #104. Fixes #106.

Instructions for setting up zigpy-znp with the custom deps deployment addon are here: https://github.com/zigpy/zigpy-znp#testing-dev-with-home-assistant-os. Use the following config for this branch:

```yaml
apk: []
pypi:
  - git+https://github.com/puddly/zigpy-znp.git@puddly/fix-slaesh-bootloader
  - zigpy==0.42.0
```