### PR TITLE
Add ZDO converter for Mgmt_Bind_req; update return format to match zigpy expectations

### DIFF
--- a/zigpy_znp/commands/zdo.py
+++ b/zigpy_znp/commands/zdo.py
@@ -100,16 +100,7 @@ class GroupIdList(t.LVList, item_type=t.GroupId, length_type=t.uint8_t):
     pass
 
 
-class BindEntry(t.Struct):
-    """Bind table entry."""
-
-    Src: t.EUI64
-    SrcEp: t.uint8_t
-    ClusterId: t.ClusterId
-    DstAddr: zigpy.zdo.types.MultiAddress
-
-
-class BindEntryList(t.LVList, item_type=BindEntry, length_type=t.uint8_t):
+class BindEntryList(t.LVList, item_type=zigpy.zdo.types.Binding, length_type=t.uint8_t):
     pass
 
 
@@ -1205,12 +1196,12 @@ class ZDO(t.CommandsBase, subsystem=t.Subsystem.ZDO):
                 "Status", t.ZDOStatus, "Status is either Success (0) or Failure (1)"
             ),
             t.Param(
-                "BindTableEntries",
+                "BindingTableEntries",
                 t.uint8_t,
                 "Total number of entries available on the device",
             ),
-            t.Param("Index", t.uint8_t, "Index where the response starts"),
-            t.Param("BindTable", BindEntryList, "list of BindEntries"),
+            t.Param("StartIndex", t.uint8_t, "Index where the response starts"),
+            t.Param("BindingTableList", BindEntryList, "list of BindEntries"),
         ),
     )
 

--- a/zigpy_znp/commands/zdo.py
+++ b/zigpy_znp/commands/zdo.py
@@ -1196,12 +1196,12 @@ class ZDO(t.CommandsBase, subsystem=t.Subsystem.ZDO):
                 "Status", t.ZDOStatus, "Status is either Success (0) or Failure (1)"
             ),
             t.Param(
-                "BindingTableEntries",
+                "BindTableEntries",
                 t.uint8_t,
                 "Total number of entries available on the device",
             ),
             t.Param("StartIndex", t.uint8_t, "Index where the response starts"),
-            t.Param("BindingTableList", BindEntryList, "list of BindEntries"),
+            t.Param("BindTableList", BindEntryList, "list of BindEntries"),
         ),
     )
 

--- a/zigpy_znp/zigbee/zdo_converters.py
+++ b/zigpy_znp/zigbee/zdo_converters.py
@@ -206,9 +206,9 @@ ZDO_CONVERTERS = {
                 ZDOCmd.Mgmt_Bind_rsp,
                 {
                     "Status": rsp.Status,
-                    "BindingTableEntries": rsp.BindingTableEntries,
+                    "BindingTableEntries": rsp.BindTableEntries,
                     "StartIndex": rsp.StartIndex,
-                    "BindingTableList": rsp.BindingTableList,
+                    "BindingTableList": rsp.BindTableList,
                 },
             )
         ),

--- a/zigpy_znp/zigbee/zdo_converters.py
+++ b/zigpy_znp/zigbee/zdo_converters.py
@@ -191,4 +191,26 @@ ZDO_CONVERTERS = {
         (lambda addr: c.ZDO.MgmtRtgRsp.Callback(partial=True, Src=addr.address)),
         (lambda rsp: (ZDOCmd.Mgmt_Rtg_rsp, {"Status": rsp.Status})),
     ),
+    ZDOCmd.Mgmt_Bind_req: (
+        (
+            lambda addr, StartIndex: (
+                c.ZDO.MgmtBindReq.Req(
+                    Dst=addr.address,
+                    StartIndex=StartIndex,
+                )
+            )
+        ),
+        (lambda addr: c.ZDO.MgmtBindRsp.Callback(partial=True, Src=addr.address)),
+        (
+            lambda rsp: (
+                ZDOCmd.Mgmt_Bind_rsp,
+                {
+                    "Status": rsp.Status,
+                    "BindingTableEntries": rsp.BindingTableEntries,
+                    "StartIndex": rsp.StartIndex,
+                    "BindingTableList": rsp.BindingTableList,
+                },
+            )
+        ),
+    ),
 }


### PR DESCRIPTION
This adds a ZDO converter for the `Mgmt_Bind_req` request and fixes the response mapping back to zigpy. This request fetches the binding table from a device.

The field names in the existing ZDO command definition didn't match the expected names at https://github.com/zigpy/zigpy/blob/77dec68ab51a9205535a0b47ae2f6f27f27ec73f/zigpy/zdo/types.py#L664-L669

Ideally, I think this should follow the same pattern used for `Neighbors` and `Routes`, with a struct defined in zigpy for the binding table collection. However, since that involves coordinating PRs across both repos and could break compatibility, we'll stick with this smaller change.

I didn't add any tests for this, because none of the similar requests like `Mgmt_Lqi_req` or `Mgmt_Rtg_req` seemed to have test coverage. I'm happy to take a stab at adding tests for it if there's a pattern anyone can point me to for testing the ZDO converters.