### PR TITLE
Fix joins through a specific node timing out

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
       - id: debug-statements
 
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
 

--- a/tests/application/test_requests.py
+++ b/tests/application/test_requests.py
@@ -21,10 +21,13 @@ from ..conftest import (
 )
 
 
-@pytest.mark.parametrize("device", FORMED_DEVICES)
+@pytest.mark.parametrize("device", [FormedLaunchpadCC26X2R1])
 async def test_chosen_dst_endpoint(device, make_application, mocker):
     app, znp_server = make_application(device)
     await app.startup(auto_form=False)
+
+    build = mocker.patch.object(type(app), "_zstack_build_id", mocker.PropertyMock())
+    build.return_value = 20200708
 
     cluster = mocker.Mock()
     cluster.endpoint.endpoint_id = 2

--- a/tests/application/test_startup.py
+++ b/tests/application/test_startup.py
@@ -20,7 +20,7 @@ from ..conftest import (
 
 DEV_NETWORK_SETTINGS = {
     FormedLaunchpadCC26X2R1: (
-        "CC1352/CC2652, Z-Stack 3.30+ (build 20200805)",
+        f"CC1352/CC2652, Z-Stack 3.30+ (build {FormedLaunchpadCC26X2R1.code_revision})",
         15,
         t.Channels.from_channel_list([15]),
         0x4402,
@@ -28,7 +28,7 @@ DEV_NETWORK_SETTINGS = {
         t.KeyData.convert("4C:4E:72:B8:41:22:51:79:9A:BF:35:25:12:88:CA:83"),
     ),
     FormedZStack3CC2531: (
-        "CC2531, Z-Stack 3.0.x (build 20190425)",
+        f"CC2531, Z-Stack 3.0.x (build {FormedZStack3CC2531.code_revision})",
         15,
         t.Channels.from_channel_list([15]),
         0xB6AB,
@@ -36,7 +36,7 @@ DEV_NETWORK_SETTINGS = {
         t.KeyData.convert("6D:DE:24:EA:E2:85:52:B6:DE:29:56:EB:05:85:1A:FA"),
     ),
     FormedZStack1CC2531: (
-        "CC2531, Z-Stack Home 1.2 (build 20190608)",
+        f"CC2531, Z-Stack Home 1.2 (build {FormedZStack1CC2531.code_revision})",
         11,
         t.Channels.from_channel_list([11]),
         0x1A62,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1111,7 +1111,7 @@ class BaseZStack3Device(BaseZStackDevice):
 class BaseLaunchpadCC26X2R1(BaseZStack3Device):
     version = 3.30
     align_structs = True
-    code_revision = 20200805
+    code_revision = 20220219
 
     def _create_network_nvram(self):
         super()._create_network_nvram()

--- a/zigpy_znp/types/commands.py
+++ b/zigpy_znp/types/commands.py
@@ -345,7 +345,7 @@ class CommandBase:
                     and not issubclass(param.type, enum.Enum),
 
                     isinstance(value, bytes)
-                    and issubclass(param.type, (t.ShortBytes, t.LongBytes)),
+                    and issubclass(param.type, (t.ShortBytes, t.LongBytes, t.Bytes)),
 
                     isinstance(value, list) and issubclass(param.type, list),
                     isinstance(value, bool) and issubclass(param.type, t.Bool),

--- a/zigpy_znp/zigbee/application.py
+++ b/zigpy_znp/zigbee/application.py
@@ -1236,6 +1236,13 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             # addressing another device. The router will receive the ZDO request and a
             # device will try to join, but Z-Stack will never send the network key.
             if cluster == zdo_t.ZDOCmd.Mgmt_Permit_Joining_req:
+                if dst_addr.mode == t.AddrMode.Broadcast:
+                    # The coordinator responds to broadcasts
+                    permit_addr = 0x0000
+                else:
+                    # Otherwise, the destination device responds
+                    permit_addr = dst_addr.address
+
                 await self._znp.request_callback_rsp(
                     request=c.ZDO.MgmtPermitJoinReq.Req(
                         AddrMode=dst_addr.mode,
@@ -1244,7 +1251,9 @@ class ControllerApplication(zigpy.application.ControllerApplication):
                         TCSignificance=data[2],
                     ),
                     RspStatus=t.Status.SUCCESS,
-                    callback=c.ZDO.MgmtPermitJoinRsp.Callback(Src=0x0000, partial=True),
+                    callback=c.ZDO.MgmtPermitJoinRsp.Callback(
+                        Src=permit_addr, partial=True
+                    ),
                 )
             # Internally forward ZDO requests destined for the coordinator back to zigpy
             # so we can send internal Z-Stack requests when necessary


### PR DESCRIPTION
The request was being successfully sent and joins were being permitted but zigpy-znp was waiting for a callback with the wrong address, causing the `permit` call to timeout.

Fixes #148