### PR TITLE
Fix zigpy initialization not being run on reconnect

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ python_requires = >=3.7
 install_requires =
     pyserial-asyncio; platform_system!="Windows"
     pyserial-asyncio!=0.5; platform_system=="Windows"  # 0.5 broke writes
-    zigpy>=0.47.0
+    zigpy>=0.50.0
     async_timeout
     voluptuous
     coloredlogs

--- a/zigpy_znp/zigbee/application.py
+++ b/zigpy_znp/zigbee/application.py
@@ -884,7 +884,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
 
             try:
                 await self.connect()
-                await self.start_network()
+                await self.initialize()
                 return
             except asyncio.CancelledError:
                 raise


### PR DESCRIPTION
Related to https://github.com/zigpy/bellows/pull/483

`start_network` alone won't run `permit(0)`. If a CC2531 has required a reconnect at runtime, this will re-exposes the CC2531 Z-Stack Home 1.2 bug that erroneously leaves joins open on startup.