### PR TITLE
Bump minimum testing dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ testpaths = ["tests"]
 timeout = 20
 log_format = "%(asctime)s.%(msecs)03d %(levelname)s %(message)s"
 log_date_format = "%Y-%m-%d %H:%M:%S"
+asyncio_mode = "auto"
 
 [tool.flake8]
 exclude = ".venv,.git,.tox,docs,venv,bin,lib,deps,build"

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,10 +29,10 @@ exclude =
 [options.extras_require]
 # XXX: The order of these deps seems to matter
 testing =
-    pytest>=5.4.5
-    pytest-asyncio>=0.12.0
-    pytest-timeout
-    pytest-mock
-    pytest-cov
+    pytest>=7.1.2
+    pytest-asyncio>=0.19.0
+    pytest-timeout>=2.1.0
+    pytest-mock>=3.8.2
+    pytest-cov>=3.0.0
     coveralls
     asynctest; python_version < "3.8.0"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,7 +40,6 @@ def pytest_collection_modifyitems(session, config, items):
             pytest.mark.filterwarnings("error::pytest.PytestUnraisableExceptionWarning")
         )
         item.add_marker(pytest.mark.filterwarnings("error::RuntimeWarning"))
-        item.add_marker(pytest.mark.asyncio)
 
 
 class ForwardingSerialTransport:
@@ -91,7 +90,7 @@ def config_for_port_path(path):
 
 
 @pytest.fixture
-async def make_znp_server(mocker):
+def make_znp_server(mocker):
     transports = []
 
     def inner(server_cls, config=None, shorten_delays=True):


### PR DESCRIPTION
Fixes a recent issue with pytest failing on an incorrectly-defined `async` fixture.