### PR TITLE
[WIP] Use a dedicated thread for Zigpy ZNP's serial communication 

### DIFF
--- a/zigpy_znp/api.py
+++ b/zigpy_znp/api.py
@@ -21,7 +21,7 @@ import zigpy_znp.types as t
 import zigpy_znp.config as conf
 import zigpy_znp.logger as log
 import zigpy_znp.commands as c
-from zigpy_znp import uart
+from zigpy_znp import uart, async_utils
 from zigpy_znp.nvram import NVRAMHelper
 from zigpy_znp.utils import (
     CatchAllResponse,

--- a/zigpy_znp/api.py
+++ b/zigpy_znp/api.py
@@ -21,7 +21,7 @@ import zigpy_znp.types as t
 import zigpy_znp.config as conf
 import zigpy_znp.logger as log
 import zigpy_znp.commands as c
-from zigpy_znp import uart, async_utils
+from zigpy_znp import uart
 from zigpy_znp.nvram import NVRAMHelper
 from zigpy_znp.utils import (
     CatchAllResponse,

--- a/zigpy_znp/async_utils.py
+++ b/zigpy_znp/async_utils.py
@@ -16,7 +16,7 @@ hass_loop = None
 def init():
     global znp_loop, hass_loop
     if hass_loop is None:
-        try
+        try:
             hass_loop = asyncio.get_running_loop()
         except RuntimeError:
             hass_loop = asyncio.new_event_loop()

--- a/zigpy_znp/async_utils.py
+++ b/zigpy_znp/async_utils.py
@@ -1,7 +1,10 @@
 import typing
 import asyncio
 import logging
+import functools
 import threading
+import dataclasses
+
 
 LOGGER = logging.getLogger(__name__)
 

--- a/zigpy_znp/async_utils.py
+++ b/zigpy_znp/async_utils.py
@@ -6,13 +6,20 @@ import threading
 LOGGER = logging.getLogger(__name__)
 
 
-_znp_loop = None
-_worker_loop = None
+_znp_loop = None  # the loop in which the serial communication will be handled
+_worker_loop = (
+    None  # the loop in which the frames are handled (MainThread in home assistant)
+)
 
+# if there is a need to create a worker loop this will be the thread it is running in
 _worker_loop_thread = None
 
 
 def try_get_running_loop_as_worker_loop():
+    """
+    this function will set the worker loop to the currently running loop
+    (if there is one).
+    """
     global _worker_loop
     if _worker_loop is None:
         try:
@@ -21,10 +28,15 @@ def try_get_running_loop_as_worker_loop():
             pass
 
 
+# this will get the running loop in case of integration in home assistant
+# if there is no running loop, a loop will be created later
 try_get_running_loop_as_worker_loop()
 
 
 def get_worker_loop():
+    """
+    Getter for the worker loop.
+    """
     global _worker_loop
     if _worker_loop is None:
         try:
@@ -36,10 +48,16 @@ def get_worker_loop():
 
 
 def get_znp_loop():
+    """
+    Getter for the ZNP serial loop.
+    """
     return _znp_loop
 
 
 def start_worker_loop_in_thread():
+    """
+    Create a thread and run the worker loop.
+    """
     global _worker_loop_thread, _worker_loop
     if _worker_loop_thread is None and _worker_loop is not None:
 
@@ -54,6 +72,9 @@ def start_worker_loop_in_thread():
 
 
 def create_new_worker_loop(start_thread: bool = True):
+    """
+    Creates a new worker loop, starts a new thread too, if start_thread is True.
+    """
     global _worker_loop
     LOGGER.info("creating new event loop as worker loop")
     _worker_loop = asyncio.new_event_loop()
@@ -62,6 +83,9 @@ def create_new_worker_loop(start_thread: bool = True):
 
 
 def init_znp_loop():
+    """
+    Create and run ZNP loop.
+    """
     global _znp_loop
     if _znp_loop is None:
         _znp_loop = asyncio.new_event_loop()
@@ -76,18 +100,32 @@ def init_znp_loop():
         znp_thread.start()
 
 
+# will create and start a new ZNP loop on module initialization
 if _znp_loop is None:
     init_znp_loop()
-
-
-def delegate_to_worker_thread(coro, wait: bool = True):
-    future = asyncio.run_coroutine_threadsafe(coro, get_worker_loop())
-    return future.result() if wait else None
 
 
 def run_in_loop(
     function, loop=None, loop_getter=None, wait_for_result: bool = True, *args, **kwargs
 ):
+    """
+    Can be used as decorator or as normal function.
+    Will run the function in the specified loop.
+    @param function:
+    The co-routine that shall be run (function call only)
+    @param loop:
+    Loop in which the co-routine shall run (either loop or loop_getter must be set)
+    @param loop_getter:
+    Getter for the loop in which the co-routine shall run
+    (either loop or loop_getter must be set)
+    @param wait_for_result:
+    Will "fire and forget" if false. Otherwise,
+    the return value of the coro is returned.
+    @param args: args
+    @param kwargs: kwargs
+    @return:
+    None if wait_for_result is false. Otherwise, the return value of the co-routine.
+    """
     if loop is None and loop_getter is None:
         raise RuntimeError("either loop or loop_getter must be passed to run_in_loop")
 
@@ -99,6 +137,8 @@ def run_in_loop(
     else:
         # probably a decorator
 
+        # wrap the function in a new function,
+        # that will run the co-routine in the loop provided
         @functools.wraps(function)
         def new_sync(*args, **kwargs):
             loop if loop is not None else loop_getter()
@@ -109,20 +149,49 @@ def run_in_loop(
                 wait_for_result=wait_for_result,
             )
 
-        async def new_async(*args, **kwargs):
-            return new_sync(*args, **kwargs)
-
-        if asyncio.iscoroutinefunction(function):
-            return new_async
-        else:
+        if not asyncio.iscoroutinefunction(function):
             return new_sync
+        else:
+            # wrap the function again in an async function, so that it can be awaited
+            async def new_async(*args, **kwargs):
+                return new_sync(*args, **kwargs)
+
+            return new_async
 
 
 def run_in_znp_loop(*args, **kwargs):
+    """
+    Can be used as decorator or as normal function.
+    Will run the function in the znp loop.
+    @param function:
+    The co-routine that shall be run (function call only)
+    @param wait_for_result:
+    Will "fire and forget" if false.
+    Otherwise, the return value of the coro is returned.
+    @param args: args
+    @param kwargs: kwargs
+    @return:
+    None if wait_for_result is false.
+    Otherwise, the return value of the co-routine.
+    """
     kwargs["loop_getter"] = get_znp_loop
     return run_in_loop(*args, **kwargs)
 
 
 def run_in_worker_loop(*args, **kwargs):
+    """
+    Can be used as decorator or as normal function.
+    Will run the function in the worker loop.
+    @param function:
+    The co-routine that shall be run (function call only)
+    @param wait_for_result:
+    Will "fire and forget" if false.
+    Otherwise, the return value of the coro is returned.
+    @param args: args
+    @param kwargs: kwargs
+    @return:
+    None if wait_for_result is false.
+    Otherwise, the return value of the co-routine.
+    """
     kwargs["loop_getter"] = get_worker_loop
     return run_in_loop(*args, **kwargs)

--- a/zigpy_znp/async_utils.py
+++ b/zigpy_znp/async_utils.py
@@ -1,0 +1,46 @@
+import typing
+import asyncio
+import logging
+import threading
+
+LOGGER = logging.getLogger(__name__)
+
+
+znp_loop = None
+hass_loop = None
+
+
+def init():
+	global znp_loop, hass_loop
+    if hass_loop is None:
+        hass_loop = asyncio.get_running_loop()
+
+    if znp_loop is None:
+        znp_loop = asyncio.new_event_loop()
+
+        def run_znp_loop():
+            znp_loop.run_forever()
+
+        znp_thread = threading.Thread(target=run_znp_loop, daemon=True, name="ZigpyThread")
+        znp_thread.start()
+    future = asyncio.run_coroutine_threadsafe(connect2(config, api), znp_loop)
+    return future.result()
+
+if znp_loop is None:
+	init()
+
+def run_in_loop(function: typing.CoroutineFunction, loop, wait_for_result:bool=True) -> typing.CoroutineFunction | None:
+	@functools.wraps(function)
+	async def new_func(*args, **kwargs):
+	    future = asyncio.run_coroutine_threadsafe(function(*args, **kwargs), loop)
+		return future.result() if wait_for_result else None
+	return new_func
+
+def run_in_znp_loop(function: typing.CoroutineFunction, wait_for_result:bool=True) -> typing.CoroutineFunction | None:
+	global znp_loop
+	return run_in_loop(function, znp_loop, wait_for_result)
+	
+def run_in_hass_loop(function: typing.CoroutineFunction, wait_for_result:bool=True) -> typing.CoroutineFunction | None:
+	global hass_loop
+	return run_in_loop(function, hass_loop, wait_for_result)
+	

--- a/zigpy_znp/async_utils.py
+++ b/zigpy_znp/async_utils.py
@@ -34,7 +34,7 @@ def run_in_loop(function: any, loop, wait_for_result:bool=True):
     @functools.wraps(function)
     async def new_func(*args, **kwargs):
         future = asyncio.run_coroutine_threadsafe(function(*args, **kwargs), loop)
-        return future.result() if wait_for_result else None
+        return await future.result() if wait_for_result else None
     return new_func
 
 def run_in_znp_loop(function: any, wait_for_result:bool=True):

--- a/zigpy_znp/async_utils.py
+++ b/zigpy_znp/async_utils.py
@@ -9,48 +9,131 @@ import dataclasses
 LOGGER = logging.getLogger(__name__)
 
 
-znp_loop = None
-hass_loop = None
+_znp_loop = None
+_worker_loop = None
+
+_worker_loop_thread = None
 
 
-def init():
-    global znp_loop, hass_loop
-    if hass_loop is None:
+def try_get_running_loop_as_worker_loop():
+    global _worker_loop
+    if _worker_loop is None:
         try:
-            hass_loop = asyncio.get_running_loop()
+            _worker_loop = asyncio.get_running_loop()
+        except:
+            pass
+
+
+try_get_running_loop_as_worker_loop()
+
+
+def get_worker_loop():
+    global _worker_loop
+    if _worker_loop is None:
+        try:
+            _worker_loop = asyncio.get_running_loop()
+            LOGGER.info("used asyncio's running loop")
         except RuntimeError:
-            hass_loop = asyncio.new_event_loop()
+            create_new_worker_loop(True)
+    return _worker_loop
 
-            def run_hass_loop():
-                hass_loop.run_forever()
 
-            hass_fake_thread = threading.Thread(target=run_hass_loop, daemon=True, name="WorkerThread")
-            hass_fake_thread.start()
+def get_znp_loop():
+    return _znp_loop
 
-    if znp_loop is None:
-        znp_loop = asyncio.new_event_loop()
+
+def start_worker_loop_in_thread():
+    global _worker_loop_thread, _worker_loop
+    if _worker_loop_thread is None and _worker_loop is not None:
+        def run_worker_loop():
+            asyncio.set_event_loop(_worker_loop)
+            _worker_loop.thread = threading.current_thread()
+            _worker_loop.run_forever()
+
+        _worker_loop_thread = threading.Thread(target=run_worker_loop, daemon=True, name="ZigpyWorkerThread")
+        _worker_loop_thread.start()
+
+
+def create_new_worker_loop(start_thread: bool = True):
+    global _worker_loop
+    LOGGER.info("creating new event loop as worker loop")
+    _worker_loop = asyncio.new_event_loop()
+    if start_thread:
+        start_worker_loop_in_thread()
+
+
+def init_znp_loop():
+    global _znp_loop
+    if _znp_loop is None:
+        _znp_loop = asyncio.new_event_loop()
 
         def run_znp_loop():
-            znp_loop.run_forever()
+            #asyncio.set_event_loop(_znp_loop)
+            _znp_loop.thread = threading.current_thread()
+            _znp_loop.run_forever()
 
-        znp_thread = threading.Thread(target=run_znp_loop, daemon=True, name="ZigpyThread")
+        znp_thread = threading.Thread(target=run_znp_loop, daemon=True, name="ZigpySerialThread")
         znp_thread.start()
 
-if znp_loop is None:
-    init()
 
-def run_in_loop(function: any, loop, wait_for_result:bool=True):
-    @functools.wraps(function)
-    async def new_func(*args, **kwargs):
-        future = asyncio.run_coroutine_threadsafe(function(*args, **kwargs), loop)
+if _znp_loop is None:
+    init_znp_loop()
+
+
+def delegate_to_worker_thread(coro, wait: bool = True):
+    future = asyncio.run_coroutine_threadsafe(coro, get_worker_loop())
+    return future.result() if wait else None
+
+
+def run_in_loop(function: any, loop = None, loop_getter = None, wait_for_result: bool = True, *args, **kwargs):
+    if loop is None and loop_getter is None:
+        raise "either loop or loop_getter must be passed to run_in_loop"
+
+    if asyncio.iscoroutine(function):
+        # called as a function call
+        _loop = loop if loop is not None else loop_getter()
+        #_cur_loop = asyncio.get_event_loop()
+        #_run_loop = None
+        #try:
+        #    _cur_loop = asyncio.get_running_loop()
+        #except RuntimeError:
+        #    pass
+
+        #if _cur_loop is not None and _cur_loop is _loop and False:
+        if False and hasattr(_loop, "thread") and threading.current_thread().name == _loop.thread.name:
+            async def run():
+                return function()
+
+            x = _loop.run_until_complete(run)
+            #if wait_for_result and asyncio.iscoroutine(x):
+            #    return x
+            #else:
+            #    return x
+            return x
+        else:
+            future = asyncio.run_coroutine_threadsafe(function, _loop)
         return future.result() if wait_for_result else None
-    return new_func
+    else:
+        # probably a decorator
 
-def run_in_znp_loop(function: any, wait_for_result:bool=True):
-    global znp_loop
-    return run_in_loop(function, znp_loop, wait_for_result)
-	
-def run_in_hass_loop(function: any, wait_for_result:bool=True):
-    global hass_loop
-    return run_in_loop(function, hass_loop, wait_for_result)
-	
+        @functools.wraps(function)
+        def new_sync(*args, **kwargs):
+            _loop = loop if loop is not None else loop_getter()
+            return run_in_loop(function(*args, **kwargs), loop=loop, loop_getter=loop_getter, wait_for_result=wait_for_result)
+
+        async def new_async(*args, **kwargs):
+            return new_sync(*args, **kwargs)
+
+        if asyncio.iscoroutinefunction(function):
+            return new_async
+        else:
+            return new_sync
+
+
+def run_in_znp_loop(*args, **kwargs):
+    return run_in_loop(*args, **kwargs, loop_getter=get_znp_loop)
+
+
+def run_in_worker_loop(*args, **kwargs):
+    return run_in_loop(*args, **kwargs, loop_getter=get_worker_loop)
+

--- a/zigpy_znp/async_utils.py
+++ b/zigpy_znp/async_utils.py
@@ -16,7 +16,16 @@ hass_loop = None
 def init():
     global znp_loop, hass_loop
     if hass_loop is None:
-        hass_loop = asyncio.get_running_loop()
+        try
+            hass_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            hass_loop = asyncio.new_event_loop()
+
+            def run_hass_loop():
+                hass_loop.run_forever()
+
+            hass_fake_thread = threading.Thread(target=run_hass_loop, daemon=True, name="WorkerThread")
+            hass_fake_thread.start()
 
     if znp_loop is None:
         znp_loop = asyncio.new_event_loop()

--- a/zigpy_znp/async_utils.py
+++ b/zigpy_znp/async_utils.py
@@ -27,18 +27,18 @@ def init():
 if znp_loop is None:
     init()
 
-def run_in_loop(function: typing.CoroutineFunction, loop, wait_for_result:bool=True) -> typing.CoroutineFunction | None:
+def run_in_loop(function: any, loop, wait_for_result:bool=True):
     @functools.wraps(function)
     async def new_func(*args, **kwargs):
         future = asyncio.run_coroutine_threadsafe(function(*args, **kwargs), loop)
         return future.result() if wait_for_result else None
     return new_func
 
-def run_in_znp_loop(function: typing.CoroutineFunction, wait_for_result:bool=True) -> typing.CoroutineFunction | None:
+def run_in_znp_loop(function: any, wait_for_result:bool=True):
     global znp_loop
     return run_in_loop(function, znp_loop, wait_for_result)
 	
-def run_in_hass_loop(function: typing.CoroutineFunction, wait_for_result:bool=True) -> typing.CoroutineFunction | None:
+def run_in_hass_loop(function: any, wait_for_result:bool=True):
     global hass_loop
     return run_in_loop(function, hass_loop, wait_for_result)
 	

--- a/zigpy_znp/async_utils.py
+++ b/zigpy_znp/async_utils.py
@@ -11,7 +11,7 @@ hass_loop = None
 
 
 def init():
-	global znp_loop, hass_loop
+    global znp_loop, hass_loop
     if hass_loop is None:
         hass_loop = asyncio.get_running_loop()
 
@@ -27,20 +27,20 @@ def init():
     return future.result()
 
 if znp_loop is None:
-	init()
+    init()
 
 def run_in_loop(function: typing.CoroutineFunction, loop, wait_for_result:bool=True) -> typing.CoroutineFunction | None:
-	@functools.wraps(function)
-	async def new_func(*args, **kwargs):
-	    future = asyncio.run_coroutine_threadsafe(function(*args, **kwargs), loop)
-		return future.result() if wait_for_result else None
-	return new_func
+    @functools.wraps(function)
+    async def new_func(*args, **kwargs):
+        future = asyncio.run_coroutine_threadsafe(function(*args, **kwargs), loop)
+        return future.result() if wait_for_result else None
+    return new_func
 
 def run_in_znp_loop(function: typing.CoroutineFunction, wait_for_result:bool=True) -> typing.CoroutineFunction | None:
-	global znp_loop
-	return run_in_loop(function, znp_loop, wait_for_result)
+    global znp_loop
+    return run_in_loop(function, znp_loop, wait_for_result)
 	
 def run_in_hass_loop(function: typing.CoroutineFunction, wait_for_result:bool=True) -> typing.CoroutineFunction | None:
-	global hass_loop
-	return run_in_loop(function, hass_loop, wait_for_result)
+    global hass_loop
+    return run_in_loop(function, hass_loop, wait_for_result)
 	

--- a/zigpy_znp/async_utils.py
+++ b/zigpy_znp/async_utils.py
@@ -34,7 +34,7 @@ def run_in_loop(function: any, loop, wait_for_result:bool=True):
     @functools.wraps(function)
     async def new_func(*args, **kwargs):
         future = asyncio.run_coroutine_threadsafe(function(*args, **kwargs), loop)
-        return await future.result() if wait_for_result else None
+        return future.result() if wait_for_result else None
     return new_func
 
 def run_in_znp_loop(function: any, wait_for_result:bool=True):

--- a/zigpy_znp/async_utils.py
+++ b/zigpy_znp/async_utils.py
@@ -45,7 +45,6 @@ def start_worker_loop_in_thread():
 
         def run_worker_loop():
             asyncio.set_event_loop(_worker_loop)
-            _worker_loop.thread = threading.current_thread()
             _worker_loop.run_forever()
 
         _worker_loop_thread = threading.Thread(
@@ -69,7 +68,6 @@ def init_znp_loop():
 
         def run_znp_loop():
             # asyncio.set_event_loop(_znp_loop)
-            _znp_loop.thread = threading.current_thread()
             _znp_loop.run_forever()
 
         znp_thread = threading.Thread(
@@ -96,31 +94,7 @@ def run_in_loop(
     if asyncio.iscoroutine(function):
         # called as a function call
         _loop = loop if loop is not None else loop_getter()
-        # _cur_loop = asyncio.get_event_loop()
-        # _run_loop = None
-        # try:
-        #    _cur_loop = asyncio.get_running_loop()
-        # except RuntimeError:
-        #    pass
-
-        # if _cur_loop is not None and _cur_loop is _loop and False:
-        if (
-            False
-            and hasattr(_loop, "thread")
-            and threading.current_thread().name == _loop.thread.name
-        ):
-
-            async def run():
-                return function()
-
-            x = _loop.run_until_complete(run)
-            # if wait_for_result and asyncio.iscoroutine(x):
-            #    return x
-            # else:
-            #    return x
-            return x
-        else:
-            future = asyncio.run_coroutine_threadsafe(function, _loop)
+        future = asyncio.run_coroutine_threadsafe(function, _loop)
         return future.result() if wait_for_result else None
     else:
         # probably a decorator

--- a/zigpy_znp/async_utils.py
+++ b/zigpy_znp/async_utils.py
@@ -23,8 +23,6 @@ def init():
 
         znp_thread = threading.Thread(target=run_znp_loop, daemon=True, name="ZigpyThread")
         znp_thread.start()
-    future = asyncio.run_coroutine_threadsafe(connect2(config, api), znp_loop)
-    return future.result()
 
 if znp_loop is None:
     init()

--- a/zigpy_znp/tools/energy_scan.py
+++ b/zigpy_znp/tools/energy_scan.py
@@ -8,6 +8,7 @@ import zigpy.zdo.types as zdo_t
 from zigpy.exceptions import NetworkNotFormed
 
 import zigpy_znp.types as t
+from zigpy_znp import async_utils
 from zigpy_znp.tools.common import setup_parser
 from zigpy_znp.zigbee.application import ControllerApplication
 
@@ -93,4 +94,4 @@ async def main(argv):
 
 
 if __name__ == "__main__":
-    asyncio.run(main(sys.argv[1:]))  # pragma: no cover
+    async_utils.run_in_worker_loop(main(sys.argv[1:]))  # pragma: no cover

--- a/zigpy_znp/tools/energy_scan.py
+++ b/zigpy_znp/tools/energy_scan.py
@@ -1,5 +1,4 @@
 import sys
-import asyncio
 import logging
 import itertools
 from collections import deque, defaultdict

--- a/zigpy_znp/tools/flash_read.py
+++ b/zigpy_znp/tools/flash_read.py
@@ -5,6 +5,7 @@ import logging
 import async_timeout
 
 import zigpy_znp.commands as c
+from zigpy_znp import async_utils
 from zigpy_znp.api import ZNP
 from zigpy_znp.config import CONFIG_SCHEMA
 from zigpy_znp.tools.common import ClosableFileType, setup_parser
@@ -87,4 +88,4 @@ async def main(argv):
 
 
 if __name__ == "__main__":
-    asyncio.run(main(sys.argv[1:]))  # pragma: no cover
+    async_utils.run_in_worker_loop(main(sys.argv[1:]))  # pragma: no cover

--- a/zigpy_znp/tools/flash_write.py
+++ b/zigpy_znp/tools/flash_write.py
@@ -8,6 +8,7 @@ import async_timeout
 
 import zigpy_znp.types as t
 import zigpy_znp.commands as c
+from zigpy_znp import async_utils
 from zigpy_znp.api import ZNP
 from zigpy_znp.config import CONFIG_SCHEMA
 from zigpy_znp.tools.common import ClosableFileType, setup_parser
@@ -174,4 +175,4 @@ async def main(argv):
 
 
 if __name__ == "__main__":
-    asyncio.run(main(sys.argv[1:]))  # pragma: no cover
+    async_utils.run_in_worker_loop(main(sys.argv[1:]))  # pragma: no cover

--- a/zigpy_znp/tools/network_backup.py
+++ b/zigpy_znp/tools/network_backup.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import sys
 import json
-import asyncio
 import logging
 import datetime
 

--- a/zigpy_znp/tools/network_backup.py
+++ b/zigpy_znp/tools/network_backup.py
@@ -10,6 +10,7 @@ import zigpy.state
 
 import zigpy_znp
 import zigpy_znp.types as t
+from zigpy_znp import async_utils
 from zigpy_znp.api import ZNP
 from zigpy_znp.tools.common import ClosableFileType, setup_parser, validate_backup_json
 from zigpy_znp.zigbee.application import ControllerApplication
@@ -117,6 +118,8 @@ async def main(argv: list[str]) -> None:
 
         f.write(json.dumps(backup_obj, indent=4))
 
+        LOGGER.info("done")
+
 
 if __name__ == "__main__":
-    asyncio.run(main(sys.argv[1:]))  # pragma: no cover
+    async_utils.run_in_worker_loop(main(sys.argv[1:]))  # pragma: no cover

--- a/zigpy_znp/tools/network_restore.py
+++ b/zigpy_znp/tools/network_restore.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import sys
 import json
-import asyncio
 
 import zigpy.state
 import zigpy.zdo.types as zdo_t

--- a/zigpy_znp/tools/network_restore.py
+++ b/zigpy_znp/tools/network_restore.py
@@ -9,6 +9,7 @@ import zigpy.zdo.types as zdo_t
 
 import zigpy_znp.const as const
 import zigpy_znp.types as t
+from zigpy_znp import async_utils
 from zigpy_znp.api import ZNP
 from zigpy_znp.tools.common import ClosableFileType, setup_parser, validate_backup_json
 from zigpy_znp.zigbee.application import ControllerApplication
@@ -130,4 +131,4 @@ async def main(argv: list[str]) -> None:
 
 
 if __name__ == "__main__":
-    asyncio.run(main(sys.argv[1:]))  # pragma: no cover
+    async_utils.run_in_worker_loop(main(sys.argv[1:]))  # pragma: no cover

--- a/zigpy_znp/tools/network_scan.py
+++ b/zigpy_znp/tools/network_scan.py
@@ -1,6 +1,5 @@
 import sys
 import time
-import asyncio
 import logging
 import itertools
 

--- a/zigpy_znp/tools/network_scan.py
+++ b/zigpy_znp/tools/network_scan.py
@@ -6,6 +6,7 @@ import itertools
 
 import zigpy_znp.types as t
 import zigpy_znp.commands as c
+from zigpy_znp import async_utils
 from zigpy_znp.api import ZNP
 from zigpy_znp.config import CONFIG_SCHEMA
 from zigpy_znp.types.nvids import OsalNvIds
@@ -155,4 +156,4 @@ async def main(argv):
 
 
 if __name__ == "__main__":
-    asyncio.run(main(sys.argv[1:]))  # pragma: no cover
+    async_utils.run_in_worker_loop(main(sys.argv[1:]))  # pragma: no cover

--- a/zigpy_znp/tools/nvram_read.py
+++ b/zigpy_znp/tools/nvram_read.py
@@ -1,6 +1,5 @@
 import sys
 import json
-import asyncio
 import logging
 
 import zigpy_znp.types as t

--- a/zigpy_znp/tools/nvram_read.py
+++ b/zigpy_znp/tools/nvram_read.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 
 import zigpy_znp.types as t
+from zigpy_znp import async_utils
 from zigpy_znp.api import ZNP
 from zigpy_znp.config import CONFIG_SCHEMA
 from zigpy_znp.exceptions import SecurityError, CommandNotRecognized
@@ -96,4 +97,4 @@ async def main(argv):
 
 
 if __name__ == "__main__":
-    asyncio.run(main(sys.argv[1:]))  # pragma: no cover
+    async_utils.run_in_worker_loop(main(sys.argv[1:]))  # pragma: no cover

--- a/zigpy_znp/tools/nvram_reset.py
+++ b/zigpy_znp/tools/nvram_reset.py
@@ -2,6 +2,7 @@ import sys
 import asyncio
 import logging
 
+from zigpy_znp import async_utils
 from zigpy_znp.api import ZNP
 from zigpy_znp.config import CONFIG_SCHEMA
 from zigpy_znp.types.nvids import (
@@ -79,4 +80,4 @@ async def main(argv):
 
 
 if __name__ == "__main__":
-    asyncio.run(main(sys.argv[1:]))  # pragma: no cover
+    async_utils.run_in_worker_loop(main(sys.argv[1:]))  # pragma: no cover

--- a/zigpy_znp/tools/nvram_reset.py
+++ b/zigpy_znp/tools/nvram_reset.py
@@ -1,5 +1,4 @@
 import sys
-import asyncio
 import logging
 
 from zigpy_znp import async_utils

--- a/zigpy_znp/tools/nvram_write.py
+++ b/zigpy_znp/tools/nvram_write.py
@@ -1,6 +1,5 @@
 import sys
 import json
-import asyncio
 import logging
 
 from zigpy_znp import async_utils

--- a/zigpy_znp/tools/nvram_write.py
+++ b/zigpy_znp/tools/nvram_write.py
@@ -3,6 +3,7 @@ import json
 import asyncio
 import logging
 
+from zigpy_znp import async_utils
 from zigpy_znp.api import ZNP
 from zigpy_znp.config import CONFIG_SCHEMA
 from zigpy_znp.types.nvids import ExNvIds, OsalNvIds
@@ -68,4 +69,4 @@ async def main(argv):
 
 
 if __name__ == "__main__":
-    asyncio.run(main(sys.argv[1:]))  # pragma: no cover
+    async_utils.run_in_worker_loop(main(sys.argv[1:]))  # pragma: no cover

--- a/zigpy_znp/uart.py
+++ b/zigpy_znp/uart.py
@@ -6,10 +6,10 @@ import warnings
 
 import serial
 
-import zigpy_znp.async_utils
 import zigpy_znp.config as conf
 import zigpy_znp.frames as frames
 import zigpy_znp.logger as log
+from zigpy_znp.async_utils import *
 from zigpy_znp.types import Bytes
 from zigpy_znp.exceptions import InvalidFrame
 

--- a/zigpy_znp/uart.py
+++ b/zigpy_znp/uart.py
@@ -78,7 +78,9 @@ class ZnpMtProtocol(asyncio.Protocol):
             LOGGER.log(log.TRACE, "Parsed frame: %s", frame)
 
             try:
-                self._api.frame_received(frame.payload)
+                async def _frame_received(payload):
+                    self._api.frame_received(payload)
+                future = asyncio.run_coroutine_threadsafe(_frame_received(frame.payload), async_utils.hass_loop)
             except Exception as e:
                 LOGGER.error(
                     "Received an exception while passing frame to API: %s",

--- a/zigpy_znp/uart.py
+++ b/zigpy_znp/uart.py
@@ -46,9 +46,9 @@ class ZnpMtProtocol(asyncio.Protocol):
         if self._transport is not None:
             LOGGER.debug("Closing serial port")
             
-            async def close_transport():
+            async def _close_transport():
                 self._transport.close()
-            future = asyncio.run_coroutine_threadsafe(_frame_received(frame.payload), async_utils.znp_loop)
+            future = asyncio.run_coroutine_threadsafe(_close_transport(), async_utils.znp_loop)
             future.result()
             self._transport = None
 

--- a/zigpy_znp/uart.py
+++ b/zigpy_znp/uart.py
@@ -171,9 +171,6 @@ class ZnpMtProtocol(asyncio.Protocol):
             f">"
         )
 
-znp_loop = None
-hass_loop = None
-
 async def connect3(config: conf.ConfigType, api) -> ZnpMtProtocol:
     global hass_loop, znp_loop
 
@@ -194,7 +191,7 @@ async def connect3(config: conf.ConfigType, api) -> ZnpMtProtocol:
 
 @async_utils.run_in_znp_loop
 async def connect(config: conf.ConfigType, api) -> ZnpMtProtocol:
-    loop = znp_loop
+    loop = asyncio.get_running_loop()
 
     port = config[conf.CONF_DEVICE_PATH]
     baudrate = config[conf.CONF_DEVICE_BAUDRATE]

--- a/zigpy_znp/uart.py
+++ b/zigpy_znp/uart.py
@@ -6,10 +6,10 @@ import warnings
 
 import serial
 
+import zigpy_znp.async_utils
 import zigpy_znp.config as conf
 import zigpy_znp.frames as frames
 import zigpy_znp.logger as log
-from zigpy_znp.async_utils import *
 from zigpy_znp.types import Bytes
 from zigpy_znp.exceptions import InvalidFrame
 

--- a/zigpy_znp/uart.py
+++ b/zigpy_znp/uart.py
@@ -1,5 +1,4 @@
 import typing
-import async_utils
 import asyncio
 import logging
 import threading
@@ -7,6 +6,7 @@ import warnings
 
 import serial
 
+import zigpy_znp.async_utils
 import zigpy_znp.config as conf
 import zigpy_znp.frames as frames
 import zigpy_znp.logger as log

--- a/zigpy_znp/uart.py
+++ b/zigpy_znp/uart.py
@@ -2,18 +2,16 @@ import typing
 import asyncio
 import logging
 import threading
-import warnings
 
 import serialpy as serial
 import serialpy as serial_asyncio
 
-import zigpy_znp.async_utils as async_utils
 import zigpy_znp.config as conf
 import zigpy_znp.frames as frames
 import zigpy_znp.logger as log
+import zigpy_znp.async_utils as async_utils
 from zigpy_znp.types import Bytes
 from zigpy_znp.exceptions import InvalidFrame
-
 
 LOGGER = logging.getLogger(__name__)
 
@@ -71,9 +69,13 @@ class ZnpMtProtocol(asyncio.Protocol):
             LOGGER.log(log.TRACE, "Parsed frame: %s", frame)
 
             try:
+
                 async def _frame_received(payload):
                     self._api.frame_received(payload)
-                async_utils.run_in_worker_loop(_frame_received(frame.payload), wait_for_result=False)
+
+                async_utils.run_in_worker_loop(
+                    _frame_received(frame.payload), wait_for_result=False
+                )
             except Exception as e:
                 LOGGER.error(
                     "Received an exception while passing frame to API: %s",
@@ -175,7 +177,12 @@ async def connect(config: conf.ConfigType, api) -> ZnpMtProtocol:
     baudrate = config[conf.CONF_DEVICE_BAUDRATE]
     flow_control = config[conf.CONF_DEVICE_FLOW_CONTROL]
 
-    LOGGER.debug("Connecting to %s at %s baud in thread %s", port, baudrate, threading.current_thread().name)
+    LOGGER.debug(
+        "Connecting to %s at %s baud in thread %s",
+        port,
+        baudrate,
+        threading.current_thread().name,
+    )
 
     _, protocol = await serial_asyncio.create_serial_connection(
         loop=loop,

--- a/zigpy_znp/uart.py
+++ b/zigpy_znp/uart.py
@@ -1,4 +1,5 @@
 import typing
+import async_utils
 import asyncio
 import logging
 import threading
@@ -173,7 +174,7 @@ class ZnpMtProtocol(asyncio.Protocol):
 znp_loop = None
 hass_loop = None
 
-async def connect(config: conf.ConfigType, api) -> ZnpMtProtocol:
+async def connect3(config: conf.ConfigType, api) -> ZnpMtProtocol:
     global hass_loop, znp_loop
 
     if hass_loop is None:
@@ -191,7 +192,8 @@ async def connect(config: conf.ConfigType, api) -> ZnpMtProtocol:
     return future.result()
 
 
-async def connect2(config: conf.ConfigType, api) -> ZnpMtProtocol:
+@run_in_znp_loop
+async def connect(config: conf.ConfigType, api) -> ZnpMtProtocol:
     loop = znp_loop
 
     port = config[conf.CONF_DEVICE_PATH]

--- a/zigpy_znp/uart.py
+++ b/zigpy_znp/uart.py
@@ -37,8 +37,12 @@ class ZnpMtProtocol(asyncio.Protocol):
         if self._transport is not None:
             LOGGER.debug("Closing serial port")
 
-            self._transport.close()
-            self._transport = None
+            @async_utils.run_in_worker_loop
+            def close_transport():
+                self._transport.close()
+                self._transport = None
+
+            close_transport()
 
     def connection_lost(self, exc: typing.Optional[Exception]) -> None:
         """Connection lost."""

--- a/zigpy_znp/uart.py
+++ b/zigpy_znp/uart.py
@@ -6,7 +6,7 @@ import warnings
 
 import serial
 
-import zigpy_znp.async_utils
+import zigpy_znp.async_utils as async_utils
 import zigpy_znp.config as conf
 import zigpy_znp.frames as frames
 import zigpy_znp.logger as log
@@ -192,7 +192,7 @@ async def connect3(config: conf.ConfigType, api) -> ZnpMtProtocol:
     return future.result()
 
 
-@run_in_znp_loop
+@async_utils.run_in_znp_loop
 async def connect(config: conf.ConfigType, api) -> ZnpMtProtocol:
     loop = znp_loop
 

--- a/zigpy_znp/uart.py
+++ b/zigpy_znp/uart.py
@@ -45,8 +45,11 @@ class ZnpMtProtocol(asyncio.Protocol):
 
         if self._transport is not None:
             LOGGER.debug("Closing serial port")
-
-            self._transport.close()
+            
+            async def close_transport():
+                self._transport.close()
+            future = asyncio.run_coroutine_threadsafe(_frame_received(frame.payload), async_utils.znp_loop)
+            future.result()
             self._transport = None
 
     def connection_lost(self, exc: typing.Optional[Exception]) -> None:

--- a/zigpy_znp/utils.py
+++ b/zigpy_znp/utils.py
@@ -73,13 +73,6 @@ class BaseResponseListener:
 
         if not any(c.matches(response) for c in self.matching_commands):
             return False
-        #from zigpy_znp.async_utils import hass_loop
-        #_self = self
-        #async def _resolve() -> bool:
-        #    return _self._resolve(response)
-        #future = asyncio.run_coroutine_threadsafe(_resolve(), hass_loop)
-        #return future.result()
-        #return True
         return self._resolve(response)
 
     def _resolve(self, response: t.CommandBase) -> bool:

--- a/zigpy_znp/utils.py
+++ b/zigpy_znp/utils.py
@@ -73,13 +73,14 @@ class BaseResponseListener:
 
         if not any(c.matches(response) for c in self.matching_commands):
             return False
-        from zigpy_znp.async_utils import hass_loop
-        _self = self
-        async def _resolve() -> bool:
-            return _self._resolve(response)
-        future = asyncio.run_coroutine_threadsafe(_resolve(), hass_loop)
+        #from zigpy_znp.async_utils import hass_loop
+        #_self = self
+        #async def _resolve() -> bool:
+        #    return _self._resolve(response)
+        #future = asyncio.run_coroutine_threadsafe(_resolve(), hass_loop)
         #return future.result()
-        return True
+        #return True
+        return self._resolve()
 
     def _resolve(self, response: t.CommandBase) -> bool:
         """

--- a/zigpy_znp/utils.py
+++ b/zigpy_znp/utils.py
@@ -73,7 +73,7 @@ class BaseResponseListener:
 
         if not any(c.matches(response) for c in self.matching_commands):
             return False
-        from zigpy_znp.uart import hass_loop
+        from zigpy_znp.async_utils import hass_loop
         _self = self
         async def _resolve() -> bool:
             return _self._resolve(response)

--- a/zigpy_znp/utils.py
+++ b/zigpy_znp/utils.py
@@ -80,7 +80,7 @@ class BaseResponseListener:
         #future = asyncio.run_coroutine_threadsafe(_resolve(), hass_loop)
         #return future.result()
         #return True
-        return self._resolve()
+        return self._resolve(response)
 
     def _resolve(self, response: t.CommandBase) -> bool:
         """

--- a/zigpy_znp/utils.py
+++ b/zigpy_znp/utils.py
@@ -73,8 +73,13 @@ class BaseResponseListener:
 
         if not any(c.matches(response) for c in self.matching_commands):
             return False
-
-        return self._resolve(response)
+        from zigpy_znp.uart import hass_loop
+        _self = self
+        async def _resolve() -> bool:
+            return _self._resolve(response)
+        future = asyncio.run_coroutine_threadsafe(_resolve(), hass_loop)
+        #return future.result()
+        return True
 
     def _resolve(self, response: t.CommandBase) -> bool:
         """


### PR DESCRIPTION
I have been playing around with letting zigpy-znp run in a dedicated thread.
My experience has been surprisingly pleasing. I feel like lights respond quicker (especially when toggling a bunch of lights simultaneously)

I am quite new to Python and a rudimentary understanding of event loops, but I believe this solution is worth being looked at.

I very much appreciate feedback.

I will take a look at bellows to see if I can learn something from there soon.