### PR TITLE
Allow configuring endpoint 1 selection behavior

### DIFF
--- a/zigpy_znp/config.py
+++ b/zigpy_znp/config.py
@@ -94,6 +94,7 @@ CONF_LED_MODE = "led_mode"
 CONF_SKIP_BOOTLOADER = "skip_bootloader"
 CONF_SREQ_TIMEOUT = "sync_request_timeout"
 CONF_ARSP_TIMEOUT = "async_response_timeout"
+CONF_PREFER_ENDPOINT_1 = "prefer_endpoint_1"
 CONF_AUTO_RECONNECT_RETRY_DELAY = "auto_reconnect_retry_delay"
 CONF_CONNECT_RTS_STATES = "connect_rts_pin_states"
 CONF_CONNECT_DTR_STATES = "connect_dtr_pin_states"
@@ -113,6 +114,7 @@ CONFIG_SCHEMA = CONFIG_SCHEMA.extend(
                         CONF_AUTO_RECONNECT_RETRY_DELAY, default=5
                     ): VolPositiveNumber,
                     vol.Optional(CONF_SKIP_BOOTLOADER, default=True): cv_boolean,
+                    vol.Optional(CONF_PREFER_ENDPOINT_1, default=True): cv_boolean,
                     vol.Optional(CONF_LED_MODE, default=LEDMode.OFF): vol.Any(
                         None, EnumValue(LEDMode, transformer=bool_to_upper_str)
                     ),

--- a/zigpy_znp/zigbee/application.py
+++ b/zigpy_znp/zigbee/application.py
@@ -759,7 +759,10 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             return ZDO_ENDPOINT
 
         # Newer Z-Stack releases ignore profiles and will work properly with endpoint 1
-        if self._zstack_build_id >= 20210708:
+        if (
+            self._zstack_build_id >= 20210708
+            and self._config[conf.CONF_PREFER_ENDPOINT_1]
+        ):
             return ZHA_ENDPOINT
 
         # Always fall back to endpoint 1

--- a/zigpy_znp/zigbee/application.py
+++ b/zigpy_znp/zigbee/application.py
@@ -761,7 +761,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         # Newer Z-Stack releases ignore profiles and will work properly with endpoint 1
         if (
             self._zstack_build_id >= 20210708
-            and self._config[conf.CONF_PREFER_ENDPOINT_1]
+            and self.znp_config[conf.CONF_PREFER_ENDPOINT_1]
         ):
             return ZHA_ENDPOINT
 


### PR DESCRIPTION
Supersedes #175

@prairiesnpr I gave this some thought and I think tying the current endpoint selection logic to whether or not extra endpoints exist will modify the default behavior in cases where this will be necessary (i.e. testing a new, weird device). Instead, a new config option is used:

```yaml
zha:
  zigpy_config:
    znp_config:
      prefer_endpoint_1: false
```