### PR TITLE
Use `KeyError` when throwing a missing security material exception

### DIFF
--- a/tests/tools/test_network_backup_restore.py
+++ b/tests/tools/test_network_backup_restore.py
@@ -320,7 +320,7 @@ async def test_nwk_frame_counter_zstack33(make_connected_znp):
         znp.network_info, extended_pan_id=t.EUI64.convert("11:22:33:44:55:66:77:88")
     )
 
-    with pytest.raises(ValueError):
+    with pytest.raises(KeyError):
         await security.read_nwk_frame_counter(znp)
 
     # Writes similarly will fail

--- a/zigpy_znp/znp/security.py
+++ b/zigpy_znp/znp/security.py
@@ -106,7 +106,7 @@ async def read_nwk_frame_counter(znp: ZNP, *, ext_pan_id: t.EUI64 = None) -> t.u
             global_entry = entry
 
     if global_entry is None:
-        raise ValueError("No security material entry was found for this network")
+        raise KeyError("No security material entry was found for this network")
 
     return global_entry.FrameCounter
 


### PR DESCRIPTION
Some Sonoff sticks manage to lose the portion of NVRAM responsible for holding the frame counter, which will not be treated as a correctable error.