### PR TITLE
Bump pre-commit dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,46 +1,46 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: debug-statements
 
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 23.1.0
     hooks:
       - id: black
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
+    rev: 6.0.0
     hooks:
       - id: flake8
         entry: pflake8
         additional_dependencies: 
-          - pyproject-flake8==0.0.1a3
-          - flake8-bugbear==22.1.11
-          - flake8-comprehensions==3.8.0
-          - flake8_2020==1.6.1
-          - mccabe==0.6.1
-          - pycodestyle==2.8.0
-          - pyflakes==2.4.0
+          - pyproject-flake8==6.0.0.post1
+          - flake8-bugbear==23.1.20
+          - flake8-comprehensions==3.10.1
+          - flake8_2020==1.7.0
+          - mccabe==0.7.0
+          - pycodestyle==2.10.0
+          - pyflakes==3.0.1
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.942
+    rev: v1.0.0
     hooks:
       - id: mypy
         additional_dependencies:
           - zigpy
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.31.0
+    rev: v3.3.1
     hooks:
       - id: pyupgrade
 
   - repo: https://github.com/fsouza/autoflake8
-    rev: v0.3.1
+    rev: v0.4.0
     hooks:
       - id: autoflake8

--- a/zigpy_znp/zigbee/application.py
+++ b/zigpy_znp/zigbee/application.py
@@ -183,7 +183,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         if "tclk_seed" not in network_info.stack_specific["zstack"]:
             network_info.stack_specific["zstack"]["tclk_seed"] = os.urandom(16).hex()
 
-        return await self._znp.write_network_info(
+        await self._znp.write_network_info(
             network_info=network_info, node_info=node_info
         )
 


### PR DESCRIPTION
`isort` is broken again, despite being pinned.