### PR TITLE
Ensure auto concurrency detection works with new zigpy defaults

### DIFF
--- a/tests/application/test_startup.py
+++ b/tests/application/test_startup.py
@@ -293,3 +293,18 @@ async def test_reset_network_info(device, make_application):
 
     with pytest.raises(NetworkNotFormed):
         await app.start_network()
+
+
+@pytest.mark.parametrize(
+    "device, concurrency",
+    [
+        (FormedLaunchpadCC26X2R1, 16),
+        (FormedZStack1CC2531, 2),
+    ],
+)
+async def test_concurrency_auto_config(device, concurrency, make_application):
+    app, znp_server = await make_application(server_cls=device)
+    await app.connect()
+    await app.start_network()
+
+    assert app._concurrent_requests_semaphore.max_value == concurrency

--- a/zigpy_znp/zigbee/application.py
+++ b/zigpy_znp/zigbee/application.py
@@ -16,6 +16,7 @@ import async_timeout
 import zigpy.profiles
 import zigpy.zdo.types as zdo_t
 import zigpy.application
+import zigpy.config.defaults
 from zigpy.exceptions import DeliveryError
 
 import zigpy_znp.const as const
@@ -228,7 +229,10 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             )
 
         # Now that we know what device we are, set the max concurrent requests
-        if self._config[conf.CONF_MAX_CONCURRENT_REQUESTS] is None:
+        if self._config[conf.CONF_MAX_CONCURRENT_REQUESTS] in (
+            None,
+            zigpy.config.defaults.CONF_MAX_CONCURRENT_REQUESTS_DEFAULT,
+        ):
             max_concurrent_requests = 16 if self._znp.nvram.align_structs else 2
         else:
             max_concurrent_requests = self._config[conf.CONF_MAX_CONCURRENT_REQUESTS]


### PR DESCRIPTION
Currently, the zigpy default of 8 is set for all coordinator types. This should not happen. In the future, we should move all zigpy radio libraries to set their own default.