### PR TITLE
Fail with descriptive errors when coordinator is disconnected

### DIFF
--- a/tests/api/test_request.py
+++ b/tests/api/test_request.py
@@ -318,3 +318,13 @@ async def test_handling_unknown_bad_command_parsing(connected_znp):
 
     with pytest.raises(ValueError):
         znp.frame_received(bad_frame)
+
+
+async def test_send_failure_when_disconnected(connected_znp):
+    znp, _ = connected_znp
+    znp._uart = None
+
+    with pytest.raises(RuntimeError) as e:
+        await znp.request(c.SYS.Ping.Req())
+
+    assert "Coordinator is disconnected" in str(e.value)

--- a/zigpy_znp/api.py
+++ b/zigpy_znp/api.py
@@ -969,6 +969,9 @@ class ZNP:
 
         frame = request.to_frame(align=self.nvram.align_structs)
 
+        if self._uart is None:
+            raise RuntimeError("Coordinator is disconnected, cannot send request")
+
         # We should only be sending one SREQ at a time, according to the spec
         async with self._sync_request_lock:
             LOGGER.debug("Sending request: %s", request)

--- a/zigpy_znp/zigbee/application.py
+++ b/zigpy_znp/zigbee/application.py
@@ -839,6 +839,9 @@ class ControllerApplication(zigpy.application.ControllerApplication):
                 Data=data,
             )
 
+        if self._znp is None:
+            raise DeliveryError("Coordinator is disconnected, cannot send request")
+
         # Z-Stack requires special treatment when sending ZDO requests
         if dst_ep == ZDO_ENDPOINT:
             # XXX: Joins *must* be sent via a ZDO command, even if they are directly


### PR DESCRIPTION
`AttributeError: 'NoneType' object has no attribute 'request_callback_rsp'` makes it sound like there is a library bug.