### PR TITLE
Get package version with `importlib.metadata`

### DIFF
--- a/zigpy_znp/api.py
+++ b/zigpy_znp/api.py
@@ -8,11 +8,11 @@ import logging
 import itertools
 import contextlib
 import dataclasses
+import importlib.metadata
 from collections import Counter, defaultdict
 
 import zigpy.state
 import async_timeout
-import pkg_resources
 import zigpy.zdo.types as zdo_t
 import zigpy.exceptions
 from zigpy.exceptions import NetworkNotFormed
@@ -136,10 +136,9 @@ class ZNP:
         )
 
         version = await self.request(c.SYS.Version.Req())
-        package_version = pkg_resources.get_distribution("zigpy_znp").version
 
         network_info = zigpy.state.NetworkInfo(
-            source=f"zigpy-znp@{package_version}",
+            source=f"zigpy-znp@{importlib.metadata.version('zigpy-znp')}",
             extended_pan_id=nib.extendedPANID,
             pan_id=nib.nwkPanId,
             nwk_update_id=nib.nwkUpdateId,

--- a/zigpy_znp/tools/network_backup.py
+++ b/zigpy_znp/tools/network_backup.py
@@ -5,9 +5,9 @@ import json
 import asyncio
 import logging
 import datetime
+import importlib.metadata
 
 import zigpy.state
-import pkg_resources
 
 import zigpy_znp.types as t
 from zigpy_znp.api import ZNP
@@ -84,8 +84,7 @@ async def backup_network(znp: ZNP) -> t.JSONType:
 
     now = datetime.datetime.now().astimezone()
 
-    package_version = pkg_resources.get_distribution("zigpy_znp").version
-    obj["metadata"]["source"] = f"zigpy-znp@{package_version}"
+    obj["metadata"]["source"] = f"zigpy-znp@{importlib.metadata.version('zigpy-znp')}"
     obj["metadata"]["internal"] = {
         "creation_time": now.isoformat(timespec="seconds"),
         "zstack": {


### PR DESCRIPTION
`pkg_resources` is deprecated. This may also be related to https://github.com/zigpy/zigpy-znp/issues/205.