### PR TITLE
Implement the zigpy channel changing API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 license = {text = "GPL-3.0"}
 requires-python = ">=3.8"
 dependencies = [
-    "zigpy>=0.52.0",
+    "zigpy>=0.55.0",
     "async_timeout",
     "voluptuous",
     "coloredlogs",

--- a/zigpy_znp/zigbee/application.py
+++ b/zigpy_znp/zigbee/application.py
@@ -376,6 +376,23 @@ class ControllerApplication(zigpy.application.ControllerApplication):
                 RspStatus=t.Status.SUCCESS,
             )
 
+    async def _move_network_to_channel(
+        self, new_channel: int, new_nwk_update_id: int
+    ) -> None:
+        """Moves device to a new channel."""
+        await self._znp.request(
+            request=c.ZDO.MgmtNWKUpdateReq.Req(
+                Dst=0x0000,
+                DstAddrMode=t.AddrMode.NWK,
+                Channels=t.Channels.from_channel_list([new_channel]),
+                ScanDuration=zdo_t.NwkUpdate.CHANNEL_CHANGE_REQ,
+                ScanCount=0,
+                NwkManagerAddr=0x0000,
+                # `new_nwk_update_id` is ignored
+            ),
+            RspStatus=t.Status.SUCCESS,
+        )
+
     def connection_lost(self, exc):
         """
         Propagated up from UART through ZNP when the connection is lost.

--- a/zigpy_znp/zigbee/device.py
+++ b/zigpy_znp/zigbee/device.py
@@ -1,16 +1,10 @@
 from __future__ import annotations
 
-import asyncio
 import logging
 
 import zigpy.zdo
 import zigpy.device
-import zigpy.zdo.types as zdo_t
 import zigpy.application
-
-import zigpy_znp.types as t
-import zigpy_znp.commands as c
-import zigpy_znp.zigbee.application as znp_app
 
 LOGGER = logging.getLogger(__name__)
 
@@ -21,13 +15,6 @@ class ZNPCoordinator(zigpy.device.Device):
     """
     Coordinator zigpy device that keeps track of our endpoints and clusters.
     """
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        assert hasattr(self, "zdo")
-        self.zdo = ZNPZDOEndpoint(self)
-        self.endpoints[0] = self.zdo
 
     @property
     def manufacturer(self):
@@ -71,112 +58,4 @@ class ZNPCoordinator(zigpy.device.Device):
             expect_reply=expect_reply,
             timeout=timeout,
             use_ieee=use_ieee,
-        )
-
-
-class ZNPZDOEndpoint(zigpy.zdo.ZDO):
-    @property
-    def app(self) -> zigpy.application.ControllerApplication:
-        return self.device.application
-
-    def _send_loopback_reply(
-        self, command_id: zdo_t.ZDOCmd, *, tsn: t.uint8_t, **kwargs
-    ):
-        """
-        Constructs and sends back a loopback ZDO response.
-        """
-
-        message = t.uint8_t(tsn).serialize() + self._serialize(
-            command_id, *kwargs.values()
-        )
-
-        LOGGER.debug("Sending loopback reply %s (%s), tsn=%s", command_id, kwargs, tsn)
-
-        self.app.handle_message(
-            sender=self.app._device,
-            profile=znp_app.ZDO_PROFILE,
-            cluster=command_id,
-            src_ep=znp_app.ZDO_ENDPOINT,
-            dst_ep=znp_app.ZDO_ENDPOINT,
-            message=message,
-        )
-
-    def handle_mgmt_nwk_update_req(
-        self, hdr: zdo_t.ZDOHeader, NwkUpdate: zdo_t.NwkUpdate, *, dst_addressing
-    ):
-        """
-        Handles ZDO `Mgmt_NWK_Update_req` sent to the coordinator.
-        """
-
-        self.create_catching_task(
-            self.async_handle_mgmt_nwk_update_req(
-                hdr, NwkUpdate, dst_addressing=dst_addressing
-            )
-        )
-
-    async def async_handle_mgmt_nwk_update_req(
-        self, hdr: zdo_t.ZDOHeader, NwkUpdate: zdo_t.NwkUpdate, *, dst_addressing
-    ):
-        # Energy scans are handled properly by Z-Stack, no need to do anything
-        if NwkUpdate.ScanDuration not in (
-            zdo_t.NwkUpdate.CHANNEL_CHANGE_REQ,
-            zdo_t.NwkUpdate.CHANNEL_MASK_MANAGER_ADDR_CHANGE_REQ,
-        ):
-            return
-
-        old_network_info = self.app.state.network_info
-
-        if (
-            t.Channels.from_channel_list([old_network_info.channel])
-            == NwkUpdate.ScanChannels
-        ):
-            LOGGER.warning("NWK update request is ignored when channel does not change")
-            self._send_loopback_reply(
-                zdo_t.ZDOCmd.Mgmt_NWK_Update_rsp,
-                Status=zdo_t.Status.SUCCESS,
-                ScannedChannels=t.Channels.NO_CHANNELS,
-                TotalTransmissions=0,
-                TransmissionFailures=0,
-                EnergyValues=[],
-                tsn=hdr.tsn,
-            )
-            return
-
-        await self.app._znp.request(
-            request=c.ZDO.MgmtNWKUpdateReq.Req(
-                Dst=0x0000,
-                DstAddrMode=t.AddrMode.NWK,
-                Channels=NwkUpdate.ScanChannels,
-                ScanDuration=NwkUpdate.ScanDuration,
-                # Missing fields in the request cannot be `None` in the Z-Stack command
-                ScanCount=NwkUpdate.ScanCount or 0,
-                NwkManagerAddr=NwkUpdate.nwkManagerAddr or 0x0000,
-            ),
-            RspStatus=t.Status.SUCCESS,
-        )
-
-        # Wait until the network info changes, it can take ~5s
-        while (
-            self.app.state.network_info.nwk_update_id == old_network_info.nwk_update_id
-        ):
-            await self.app.load_network_info(load_devices=False)
-            await asyncio.sleep(NWK_UPDATE_LOOP_DELAY)
-
-        # Z-Stack automatically increments the NWK update ID instead of setting it
-        # TODO: Directly set it once radio settings API is finalized.
-        if NwkUpdate.nwkUpdateId != self.app.state.network_info.nwk_update_id:
-            LOGGER.warning(
-                f"`nwkUpdateId` was incremented to"
-                f" {self.app.state.network_info.nwk_update_id} instead of being"
-                f" set to {NwkUpdate.nwkUpdateId}"
-            )
-
-        self._send_loopback_reply(
-            zdo_t.ZDOCmd.Mgmt_NWK_Update_rsp,
-            Status=zdo_t.Status.SUCCESS,
-            ScannedChannels=t.Channels.NO_CHANNELS,
-            TotalTransmissions=0,
-            TransmissionFailures=0,
-            EnergyValues=[],
-            tsn=hdr.tsn,
         )


### PR DESCRIPTION
https://github.com/zigpy/zigpy/pull/1190

Other radio libraries handle the ZDO request directly and do not need this special care. Z-Stack, however, turns this missing feature into an advantage: we can send the broadcast as many times as necessary before actually migrating the coordinator.