### PR TITLE
Use `setuptools-git-versioning`

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -14,18 +14,19 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: 3.8
-    - name: Set package version
+    - name: Build wheel
       run: |
-        version="${{ github.event.release.tag_name }}"
-        version="${version,,}"  # lowercase it
-        version="${version#v}"  # remove `v`
-        sed -i "s/version = \"0\.0\.0\"/version = \"${version}\"/" pyproject.toml
-    - name: Install wheel
-      run: >-
+        VERSION="${{ github.event.release.tag_name }}"
+        VERSION="${VERSION,,}"  # lowercase it
+        VERSION="${VERSION#v}"  # remove `v`
+
         pip install wheel build
-    - name: Build
-      run: >-
         python3 -m build
+
+        # Fail if we don't generate a package with the expected version
+        if ( ! ls -A "dist/*${VERSION}*.whl" 1> /dev/null 2>&1 ); then
+          exit 1
+        fi
     - name: Publish distribution to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools>=61.0.0"]
+requires = ["setuptools>=61.0.0", "wheel", "setuptools-git-versioning<2"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "zigpy-znp"
-version = "0.0.0"
+dynamic = ["version"]
 description = "A library for zigpy which communicates with TI ZNP radios"
 urls = {repository = "https://github.com/zigpy/zigpy-znp"}
 authors = [
@@ -33,6 +33,9 @@ testing = [
     "pytest-cov>=3.0.0",
     "coveralls",
 ]
+
+[tool.setuptools-git-versioning]
+enabled = true
 
 
 [tool.black]


### PR DESCRIPTION
Allows for automatic versioning for the generated wheel, source distributions, and installing straight from the Git repo.