### PR TITLE
Don't reassign cls.__new__ for Python 3.10+

### DIFF
--- a/zigpy_znp/types/basic.py
+++ b/zigpy_znp/types/basic.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import enum
 import sys
+import enum
 import typing
 
 import zigpy.types as zigpy_t
@@ -67,8 +67,9 @@ class FixedIntType(int):
             cls.__repr__ = super().__repr__
 
         if sys.version_info < (3, 10):
-            # XXX: The enum module uses the first class with __new__ in its __dict__ as the
-            #      member type. We have to ensure this is true for every subclass.
+            # XXX: The enum module uses the first class with __new__ in its __dict__
+            #      as the member type. We have to ensure this is true for
+            #      every subclass.
             # Fixed with https://github.com/python/cpython/pull/26658
             if "__new__" not in cls.__dict__:
                 cls.__new__ = cls.__new__

--- a/zigpy_znp/types/basic.py
+++ b/zigpy_znp/types/basic.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import enum
+import sys
 import typing
 
 import zigpy.types as zigpy_t
@@ -65,10 +66,12 @@ class FixedIntType(int):
             cls.__str__ = super().__str__
             cls.__repr__ = super().__repr__
 
-        # XXX: The enum module uses the first class with __new__ in its __dict__ as the
-        #      member type. We have to ensure this is true for every subclass.
-        if "__new__" not in cls.__dict__:
-            cls.__new__ = cls.__new__
+        if sys.version_info < (3, 10):
+            # XXX: The enum module uses the first class with __new__ in its __dict__ as the
+            #      member type. We have to ensure this is true for every subclass.
+            # Fixed with https://github.com/python/cpython/pull/26658
+            if "__new__" not in cls.__dict__:
+                cls.__new__ = cls.__new__
 
     def serialize(self) -> bytes:
         try:


### PR DESCRIPTION
I've started testing Home Assistant with Python 3.12. One common error is
```
TypeError: int() can't convert non-string with explicit base
```
After some investigation I tracked it back to `zigpy-znp` and indeed, running  the test suite results in this error
```
ImportError while loading conftest '/usr/src/tests/conftest.py'.
tests/conftest.py:27: in <module>
    import zigpy_znp.config as conf
zigpy_znp/config.py:23: in <module>
    from zigpy_znp.commands.util import LEDMode
zigpy_znp/commands/__init__.py:1: in <module>
    from .af import AF
zigpy_znp/commands/af.py:28: in <module>
    class AF(t.CommandsBase, subsystem=t.Subsystem.AF):
zigpy_znp/types/commands.py:192: in __new__
    .with_id(definition.command_id)
zigpy_znp/types/commands.py:122: in with_id
    return type(self)(self & 0x00FF | (value & 0xFF) << 8)
zigpy_znp/types/commands.py:98: in __new__
    instance = super().__new__(cls, value)
zigpy_znp/types/basic.py:48: in __new__
    instance = super().__new__(cls, *args, **kwargs)
E   TypeError: int() can't convert non-string with explicit base
```

It can be reproduced by executing just
```py
from zigpy_znp.types.commands import CommandHeader
CommandHeader().with_id(4)
```


It is likely related to a change in cpython regarding reassignments of `cls.__new__` and `super()`, see https://github.com/python/cpython/issues/106917.

As it turns out though, the reassignment isn't actually needed anymore. The tests added in 72402da pass for Python 3.10.0+ without it. Likely a side effect of https://github.com/python/cpython/pull/26658.


<details>
<summary>The complete code I used to validate this change (tested with Python 3.8 - 3.12.0b4)</summary>

```py
import enum
import sys


class FixedIntType(int):
    _signed: bool
    _size: bool

    def __new__(cls, *args, **kwargs):
        if getattr(cls, "_signed", None) is None or getattr(cls, "_size", None) is None:
            raise TypeError(f"{cls} is abstract and cannot be created")

        print(f"=> {cls}, {args=}")
        instance = super().__new__(cls, *args, **kwargs)
        return instance

    def __init_subclass__(cls, signed=None, size=None) -> None:
        super().__init_subclass__()
        if signed is not None:
            cls._signed = signed

        if size is not None:
            cls._size = size

        print(cls.__dict__)
        if sys.version_info < (3, 10):
            if "__new__" not in cls.__dict__:
                cls.__new__ = cls.__new__
                print(cls.__dict__)


class uint_t(FixedIntType, signed=False):
    pass

class uint8_t(uint_t, size=1):
    pass

class uint16_t(uint_t, size=2):
    pass


class CustomInt(uint16_t):
    def __new__(cls, value: int = 0):
        instance = super().__new__(cls, value)
        return instance

    def with_id(self, value: int):
        return type(self)(self & 0x00FF | (value & 0xFF) << 8)

CustomInt().with_id(4)



class enum_uint(uint8_t, enum.Enum):
    pass

class AddrMode(enum_uint):
    """Address mode."""

    NOT_PRESENT = 0x00
    Group = 0x01
    NWK = 0x02
    IEEE = 0x03

    Broadcast = 0x0F
```
</details> 