### PR TITLE
Use zigpy integer, enum, and bitmap types

### DIFF
--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -68,7 +68,7 @@ def test_error_code():
 
     r, rest = t.ErrorCode.deserialize(b"\xaa" + extra)
     assert rest == extra
-    assert r.name == "unknown_0xAA"
+    assert r.name == "undefined_0xaa"
 
 
 def _validate_schema(schema):

--- a/tests/test_types_basic.py
+++ b/tests/test_types_basic.py
@@ -17,8 +17,8 @@ def test_serialize_list():
     assert t.serialize_list([]) == b""
 
 
-def test_enum_uint():
-    class TestEnum(t.enum_flag_uint16):
+def test_enum():
+    class TestEnum(t.bitmap16):
         ALL = 0xFFFF
         CH_1 = 0x0001
         CH_2 = 0x0002
@@ -37,19 +37,6 @@ def test_enum_uint():
 
     assert r.serialize() == data
     assert TestEnum(0x8012).serialize() == data
-
-
-def test_abstract_ints():
-    assert issubclass(t.uint8_t, t.uint_t)
-    assert not issubclass(t.uint8_t, t.int_t)
-    assert t.int_t._signed is True
-    assert t.uint_t._signed is False
-
-    with pytest.raises(TypeError):
-        t.int_t(0)
-
-    with pytest.raises(TypeError):
-        t.FixedIntType(0)
 
 
 def test_int_too_short():
@@ -132,29 +119,6 @@ def test_lvlist_too_short():
         TestList.deserialize(b"\x04123")
 
 
-def test_hex_repr():
-    class NwkAsHex(t.uint16_t, hex_repr=True):
-        pass
-
-    nwk = NwkAsHex(0x123A)
-    assert str(nwk) == "0x123A"
-    assert repr(nwk) == "0x123A"
-
-    assert str([nwk]) == "[0x123A]"
-    assert repr([nwk]) == "[0x123A]"
-
-    # You can turn it off as well
-    class NwkWithoutHex(NwkAsHex, hex_repr=False):
-        pass
-
-    nwk = NwkWithoutHex(1234)
-    assert str(nwk) == "1234"
-    assert repr(nwk) == "1234"
-
-    assert str([nwk]) == "[1234]"
-    assert repr([nwk]) == "[1234]"
-
-
 def test_fixed_list():
     class TestList(t.FixedList, item_type=t.uint16_t, length=3):
         pass
@@ -187,7 +151,7 @@ def test_fixed_list_deserialize():
 
 
 def test_enum_instance_types():
-    class TestEnum(t.enum_uint8):
+    class TestEnum(t.enum8):
         Member = 0x00
 
     assert TestEnum._member_type_ is t.uint8_t

--- a/tests/test_types_cstruct.py
+++ b/tests/test_types_cstruct.py
@@ -273,7 +273,7 @@ def test_struct_incomplete_serialization():
 def test_old_nib_deserialize():
     PaddingByte: typing_extensions.TypeAlias = t.uint8_t
 
-    class NwkState16(t.enum_uint16):
+    class NwkState16(t.enum16):
         NWK_INIT = 0
         NWK_JOINING_ORPHAN = 1
         NWK_DISC = 2

--- a/tests/test_types_named.py
+++ b/tests/test_types_named.py
@@ -22,7 +22,7 @@ def test_status():
     assert rest == extra
     assert r == 0x33
     assert r.value == 0x33
-    assert r.name == "unknown_0x33"
+    assert r.name == "undefined_0x33"
 
 
 def test_addr_mode_address():
@@ -99,24 +99,6 @@ def test_addr_mode_address():
     assert r3 != r4
 
 
-def test_missing_status_enum():
-    class TestEnum(t.MissingEnumMixin, t.enum_uint8):
-        Member = 0x00
-
-    assert 0xFF not in list(TestEnum)
-    assert isinstance(TestEnum(0xFF), TestEnum)
-    assert TestEnum(0xFF).value == 0xFF
-    assert type(TestEnum(0xFF).value) is t.uint8_t
-
-    # Missing members that don't fit can't be created
-    with pytest.raises(ValueError):
-        TestEnum(0xFF + 1)
-
-    # Missing members that aren't integers can't be created
-    with pytest.raises(ValueError):
-        TestEnum("0xFF")
-
-
 def test_zdo_nullable_node_descriptor():
     desc1, data = c.zdo.NullableNodeDescriptor.deserialize(b"\x00")
 
@@ -131,12 +113,3 @@ def test_zdo_nullable_node_descriptor():
 
     assert not data
     assert desc2.serialize() == desc3.serialize()
-
-
-def test_missing_enum_mixin():
-    class TestEnum(t.MissingEnumMixin, t.enum_uint8):
-        FOO = 0x01
-
-    assert TestEnum(0x01) == 0x01 == TestEnum.FOO
-    assert TestEnum(0x02) == 0x02
-    assert 0x02 not in TestEnum._value2member_map_

--- a/zigpy_znp/commands/af.py
+++ b/zigpy_znp/commands/af.py
@@ -1,7 +1,7 @@
 import zigpy_znp.types as t
 
 
-class TransmitOptions(t.enum_flag_uint8):
+class TransmitOptions(t.bitmap8):
     NONE = 0
 
     # Will force the message to use Wildcard ProfileID
@@ -19,7 +19,7 @@ class TransmitOptions(t.enum_flag_uint8):
     SKIP_ROUTING = 0x80
 
 
-class LatencyReq(t.enum_uint8):
+class LatencyReq(t.enum8):
     NoLatencyReqs = 0x00
     FastBeacons = 0x01
     SlowBeacons = 0x02

--- a/zigpy_znp/commands/app_config.py
+++ b/zigpy_znp/commands/app_config.py
@@ -3,7 +3,7 @@
 import zigpy_znp.types as t
 
 
-class TimeoutIndex(t.enum_uint8):
+class TimeoutIndex(t.enum8):
     Seconds_10 = 0x00
 
     Minutes_2 = 0x01
@@ -22,7 +22,7 @@ class TimeoutIndex(t.enum_uint8):
     Minutes_16384 = 0x0E
 
 
-class CentralizedLinkKeyMode(t.enum_uint8):
+class CentralizedLinkKeyMode(t.enum8):
     UseDefault = 0x00
     UseProvidedInstallCode = 0x01
     UseProvidedInstallCodeAndFallbackToDefault = 0x02
@@ -30,7 +30,7 @@ class CentralizedLinkKeyMode(t.enum_uint8):
     UseProvidedAPSLinkKeyAndFallbackToDefault = 0x04
 
 
-class BDBCommissioningStatus(t.enum_uint8):
+class BDBCommissioningStatus(t.enum8):
     Success = 0x00
     InProgress = 0x01
     NoNetwork = 0x02
@@ -48,7 +48,7 @@ class BDBCommissioningStatus(t.enum_uint8):
     Failure = 0x0E
 
 
-class BDBCommissioningMode(t.enum_flag_uint8):
+class BDBCommissioningMode(t.bitmap8):
     NONE = 0
 
     InitiatorTouchLink = 1 << 0
@@ -59,7 +59,7 @@ class BDBCommissioningMode(t.enum_flag_uint8):
     ParentLost = 1 << 5
 
 
-class InstallCodeFormat(t.enum_uint8):
+class InstallCodeFormat(t.enum8):
     InstallCodeAndCRC = 0x01
     KeyDerivedFromInstallCode = 0x02
 

--- a/zigpy_znp/commands/rpc_error.py
+++ b/zigpy_znp/commands/rpc_error.py
@@ -1,7 +1,7 @@
 import zigpy_znp.types as t
 
 
-class ErrorCode(t.enum_uint8):
+class ErrorCode(t.enum8):
     InvalidSubsystem = 0x01
     InvalidCommandId = 0x02
     InvalidParameter = 0x03

--- a/zigpy_znp/commands/sys.py
+++ b/zigpy_znp/commands/sys.py
@@ -5,13 +5,13 @@ as reset, read/write memory, read/write extended address, etc.
 import zigpy_znp.types as t
 
 
-class BootloaderBuildType(t.enum_uint8):
+class BootloaderBuildType(t.enum8):
     NON_BOOTLOADER_BUILD = 0
     BUILT_AS_BIN = 1
     BUILT_AS_HEX = 2
 
 
-class ADCChannel(t.enum_uint8):
+class ADCChannel(t.enum8):
     """The ADC channel."""
 
     AIN0 = 0x00
@@ -26,7 +26,7 @@ class ADCChannel(t.enum_uint8):
     Voltage = 0x0F
 
 
-class ADCResolution(t.enum_uint8):
+class ADCResolution(t.enum8):
     """Resolution of the ADC channel."""
 
     bits_8 = 0x00
@@ -35,7 +35,7 @@ class ADCResolution(t.enum_uint8):
     bits_14 = 0x03
 
 
-class GPIOPinMode(t.enum_flag_uint8):
+class GPIOPinMode(t.bitmap8):
     """Pin state. Any pin with an unspecified state bit is pulled up."""
 
     Tristate0 = 0b0000_0001
@@ -49,7 +49,7 @@ class GPIOPinMode(t.enum_flag_uint8):
     PullDown3 = 0b1000_0000
 
 
-class GPIOPinDirection(t.enum_flag_uint8):
+class GPIOPinDirection(t.bitmap8):
     """Pin direction. Any pin with an unspecified direction bit is an input pin."""
 
     Output0 = 0b0000_0001
@@ -58,7 +58,7 @@ class GPIOPinDirection(t.enum_flag_uint8):
     Output3 = 0b0000_1000
 
 
-class GPIOOperation(t.enum_uint8):
+class GPIOOperation(t.enum8):
     """Specifies the type of operation to perform on the GPIO pins."""
 
     SetDirection = 0x00
@@ -70,7 +70,7 @@ class GPIOOperation(t.enum_uint8):
     HiD = 0x12  # ???
 
 
-class StackTuneOperation(t.enum_uint8):
+class StackTuneOperation(t.enum8):
     """The tuning operation to be executed."""
 
     # XXX: [Value] should correspond to the valid values specified by the

--- a/zigpy_znp/commands/ubl.py
+++ b/zigpy_znp/commands/ubl.py
@@ -11,7 +11,7 @@ IMAGE_CRC_OFFSET = 0x90
 FLASH_WORD_SIZE = 4
 
 
-class BootloaderStatus(t.enum_uint8):
+class BootloaderStatus(t.enum8):
     SUCCESS = 0
     FAILURE = 1
     INVALID_FCS = 2
@@ -23,12 +23,12 @@ class BootloaderStatus(t.enum_uint8):
     CANCELED = 8
 
 
-class BootloaderDeviceType(t.enum_uint8):
+class BootloaderDeviceType(t.enum8):
     CC2538 = 1
     CC2530 = 2
 
 
-class BootloaderRunMode(t.enum_uint8):
+class BootloaderRunMode(t.enum8):
     # Read the code, not the spec
     FORCE_BOOT = 0x10
     FORCE_RUN = FORCE_BOOT ^ 0xFF

--- a/zigpy_znp/commands/util.py
+++ b/zigpy_znp/commands/util.py
@@ -4,7 +4,7 @@ getting device info, getting NV info, subscribing callbacks, etc."""
 import zigpy_znp.types as t
 
 
-class NodeRelation(t.enum_uint8):
+class NodeRelation(t.enum8):
     PARENT = 0
     CHILD_RFD = 1
     CHILD_RFD_RX_IDLE = 2
@@ -62,7 +62,7 @@ class RandomNumbers(t.FixedList, item_type=t.uint8_t, length=100):
     pass
 
 
-class LEDMode(t.enum_uint8):
+class LEDMode(t.enum8):
     OFF = 0
     ON = 1
     BLINK = 2

--- a/zigpy_znp/commands/zdo.py
+++ b/zigpy_znp/commands/zdo.py
@@ -17,19 +17,19 @@ class SecurityEntry(t.FixedList, item_type=t.uint8_t, length=5):
     pass
 
 
-class StartupState(t.enum_uint8):
+class StartupState(t.enum8):
     RestoredNetworkState = 0x00
     NewNetworkState = 0x01
     NotStarted = 0x02
 
 
-class RouteDiscoveryOptions(t.enum_flag_uint8):
+class RouteDiscoveryOptions(t.bitmap8):
     UNICAST = 0x00
     MTO_WITH_ROUTE_CACHE = 0x01
     MTO_WITHOUT_ROUTE_CACHE = 0x03
 
 
-class RouteStatus(t.enum_uint8):
+class RouteStatus(t.enum8):
     INIT = 0
     ACTIVE = 1
     DISC = 2
@@ -37,7 +37,7 @@ class RouteStatus(t.enum_uint8):
     REPAIR = 4
 
 
-class RouteOptions(t.enum_flag_uint8):
+class RouteOptions(t.bitmap8):
     # Used in option of NLME_RouteDiscoveryRequest() and rtgTable[]
     MTO_ROUTE = 0x01
 
@@ -60,7 +60,7 @@ class RouteOptions(t.enum_flag_uint8):
     MULTICAST_ROUTE = 0x40
 
 
-class RoutingStatus(t.enum_uint8):
+class RoutingStatus(t.enum8):
     SUCCESS = 0
     FAIL = 1
     TBL_FULL = 2
@@ -71,7 +71,7 @@ class RoutingStatus(t.enum_uint8):
     SRC_TBL_FULL = 7
 
 
-class MACCapabilities(t.enum_flag_uint8):
+class MACCapabilities(t.bitmap8):
     PANCoordinator = 1 << 0
     Router = 1 << 1
     MainsPowered = 1 << 2
@@ -82,7 +82,7 @@ class MACCapabilities(t.enum_flag_uint8):
     AllocateShortAddrDuringAssocNeeded = 1 << 7
 
 
-class LeaveOptions(t.enum_flag_uint8):
+class LeaveOptions(t.bitmap8):
     NONE = 0
     Rejoin = 1 << 0
     RemoveChildren = 1 << 1
@@ -136,7 +136,7 @@ class NullableNodeDescriptor(zigpy.zdo.types.NodeDescriptor):
         return super().serialize()
 
 
-class AddrRequestType(t.enum_uint8):
+class AddrRequestType(t.enum8):
     SINGLE = 0x00
     EXTENDED = 0x01
 

--- a/zigpy_znp/commands/znp.py
+++ b/zigpy_znp/commands/znp.py
@@ -1,7 +1,7 @@
 import zigpy_znp.types as t
 
 
-class DiscreteCommand(t.enum_flag_uint8):
+class DiscreteCommand(t.bitmap8):
     ZDOStart = 0x40
     ResetNwk = 0x80
 

--- a/zigpy_znp/types/basic.py
+++ b/zigpy_znp/types/basic.py
@@ -1,12 +1,20 @@
 from __future__ import annotations
 
-import sys
-import enum
-import typing
-
-import zigpy.types as zigpy_t
+from zigpy.types import uint8_t, uint16_t, uint24_t, uint40_t, uint64_t, enum_factory
 
 from zigpy_znp.types.cstruct import CStruct
+
+
+class enum24(enum_factory(uint24_t)):  # type: ignore[misc]
+    pass
+
+
+class enum40(enum_factory(uint40_t)):  # type: ignore[misc]
+    pass
+
+
+class enum64(enum_factory(uint64_t)):  # type: ignore[misc]
+    pass
 
 
 class Bytes(bytes):
@@ -35,132 +43,6 @@ class TrailingBytes(Bytes):
 
 def serialize_list(objects) -> Bytes:
     return Bytes(b"".join([o.serialize() for o in objects]))
-
-
-class FixedIntType(int):
-    _signed: bool
-    _size: int
-
-    def __new__(cls, *args, **kwargs):
-        if getattr(cls, "_signed", None) is None or getattr(cls, "_size", None) is None:
-            raise TypeError(f"{cls} is abstract and cannot be created")
-
-        instance = super().__new__(cls, *args, **kwargs)
-        instance.serialize()
-
-        return instance
-
-    def __init_subclass__(cls, signed=None, size=None, hex_repr=None) -> None:
-        super().__init_subclass__()
-
-        if signed is not None:
-            cls._signed = signed
-
-        if size is not None:
-            cls._size = size
-
-        if hex_repr:
-            fmt = f"0x{{:0{cls._size * 2}X}}"  # type:ignore[operator]
-            cls.__str__ = cls.__repr__ = lambda self: fmt.format(self)
-        elif hex_repr is not None and not hex_repr:
-            cls.__str__ = super().__str__
-            cls.__repr__ = super().__repr__
-
-        if sys.version_info < (3, 10):
-            # XXX: The enum module uses the first class with __new__ in its __dict__
-            #      as the member type. We have to ensure this is true for
-            #      every subclass.
-            # Fixed with https://github.com/python/cpython/pull/26658
-            if "__new__" not in cls.__dict__:
-                cls.__new__ = cls.__new__
-
-    def serialize(self) -> bytes:
-        try:
-            return self.to_bytes(self._size, "little", signed=self._signed)
-        except OverflowError as e:
-            # OverflowError is not a subclass of ValueError, making it annoying to catch
-            raise ValueError(str(e)) from e
-
-    @classmethod
-    def deserialize(cls, data: bytes) -> tuple[FixedIntType, bytes]:
-        if len(data) < cls._size:
-            raise ValueError(f"Data is too short to contain {cls._size} bytes")
-
-        r = cls.from_bytes(data[: cls._size], "little", signed=cls._signed)
-        data = data[cls._size :]
-        return typing.cast(FixedIntType, r), data
-
-
-class uint_t(FixedIntType, signed=False):
-    pass
-
-
-class int_t(FixedIntType, signed=True):
-    pass
-
-
-class int8s(int_t, size=1):
-    pass
-
-
-class int16s(int_t, size=2):
-    pass
-
-
-class int24s(int_t, size=3):
-    pass
-
-
-class int32s(int_t, size=4):
-    pass
-
-
-class int40s(int_t, size=5):
-    pass
-
-
-class int48s(int_t, size=6):
-    pass
-
-
-class int56s(int_t, size=7):
-    pass
-
-
-class int64s(int_t, size=8):
-    pass
-
-
-class uint8_t(uint_t, size=1):
-    pass
-
-
-class uint16_t(uint_t, size=2):
-    pass
-
-
-class uint24_t(uint_t, size=3):
-    pass
-
-
-class uint32_t(uint_t, size=4):
-    pass
-
-
-class uint40_t(uint_t, size=5):
-    pass
-
-
-class uint48_t(uint_t, size=6):
-    pass
-
-
-class uint56_t(uint_t, size=7):
-    pass
-
-
-class uint64_t(uint_t, size=8):
-    pass
 
 
 class ShortBytes(Bytes):
@@ -268,67 +150,3 @@ class CompleteList(BaseListType):
             item, data = cls._deserialize_item(data, align=align)
             r.append(item)
         return r, data
-
-
-class enum_uint8(uint8_t, enum.Enum):
-    pass
-
-
-class enum_uint16(uint16_t, enum.Enum):
-    pass
-
-
-class enum_uint24(uint24_t, enum.Enum):
-    pass
-
-
-class enum_uint32(uint32_t, enum.Enum):
-    pass
-
-
-class enum_uint40(uint40_t, enum.Enum):
-    pass
-
-
-class enum_uint48(uint48_t, enum.Enum):
-    pass
-
-
-class enum_uint56(uint56_t, enum.Enum):
-    pass
-
-
-class enum_uint64(uint64_t, enum.Enum):
-    pass
-
-
-class enum_flag_uint8(zigpy_t.bitmap_factory(uint8_t)):  # type:ignore[misc]
-    pass
-
-
-class enum_flag_uint16(zigpy_t.bitmap_factory(uint16_t)):  # type:ignore[misc]
-    pass
-
-
-class enum_flag_uint24(zigpy_t.bitmap_factory(uint24_t)):  # type:ignore[misc]
-    pass
-
-
-class enum_flag_uint32(zigpy_t.bitmap_factory(uint32_t)):  # type:ignore[misc]
-    pass
-
-
-class enum_flag_uint40(zigpy_t.bitmap_factory(uint40_t)):  # type:ignore[misc]
-    pass
-
-
-class enum_flag_uint48(zigpy_t.bitmap_factory(uint48_t)):  # type:ignore[misc]
-    pass
-
-
-class enum_flag_uint56(zigpy_t.bitmap_factory(uint56_t)):  # type:ignore[misc]
-    pass
-
-
-class enum_flag_uint64(zigpy_t.bitmap_factory(uint64_t)):  # type:ignore[misc]
-    pass

--- a/zigpy_znp/types/basic.py
+++ b/zigpy_znp/types/basic.py
@@ -1,33 +1,56 @@
 from __future__ import annotations
 
-from zigpy.types import (  # noqa: F401
-    enum8,
-    int8s,
-    enum16,
-    bitmap8,
-    uint8_t,
-    bitmap16,
-    uint16_t,
-    uint24_t,
-    uint32_t,
-    uint40_t,
-    uint64_t,
-    enum_factory,
-)
+import typing
+
+from zigpy.types import int8s, uint8_t, enum_factory  # noqa: F401
 
 from zigpy_znp.types.cstruct import CStruct
 
+if typing.TYPE_CHECKING:
+    import enum
 
-class enum24(enum_factory(uint24_t)):  # type: ignore[misc]
-    pass
+    class enum8(int, enum.Enum):
+        pass
 
+    class enum16(int, enum.Enum):
+        pass
 
-class enum40(enum_factory(uint40_t)):  # type: ignore[misc]
-    pass
+    class enum24(int, enum.Enum):
+        pass
 
+    class enum40(int, enum.Enum):
+        pass
 
-class enum64(enum_factory(uint64_t)):  # type: ignore[misc]
-    pass
+    class enum64(int, enum.Enum):
+        pass
+
+    class bitmap8(enum.IntFlag):
+        pass
+
+    class bitmap16(enum.IntFlag):
+        pass
+
+else:
+    from zigpy.types import (  # noqa: F401
+        enum8,
+        enum16,
+        bitmap8,
+        bitmap16,
+        uint16_t,
+        uint24_t,
+        uint32_t,
+        uint40_t,
+        uint64_t,
+    )
+
+    class enum24(enum_factory(uint24_t)):  # type: ignore[misc]
+        pass
+
+    class enum40(enum_factory(uint40_t)):  # type: ignore[misc]
+        pass
+
+    class enum64(enum_factory(uint64_t)):  # type: ignore[misc]
+        pass
 
 
 class Bytes(bytes):

--- a/zigpy_znp/types/basic.py
+++ b/zigpy_znp/types/basic.py
@@ -1,6 +1,19 @@
 from __future__ import annotations
 
-from zigpy.types import uint8_t, uint16_t, uint24_t, uint40_t, uint64_t, enum_factory
+from zigpy.types import (  # noqa: F401
+    enum8,
+    int8s,
+    enum16,
+    bitmap8,
+    uint8_t,
+    bitmap16,
+    uint16_t,
+    uint24_t,
+    uint32_t,
+    uint40_t,
+    uint64_t,
+    enum_factory,
+)
 
 from zigpy_znp.types.cstruct import CStruct
 

--- a/zigpy_znp/types/commands.py
+++ b/zigpy_znp/types/commands.py
@@ -12,7 +12,7 @@ import zigpy_znp.types as t
 LOGGER = logging.getLogger(__name__)
 
 
-class CommandType(t.enum_uint8):
+class CommandType(t.enum8):
     """Command Type."""
 
     POLL = 0
@@ -26,7 +26,7 @@ class CommandType(t.enum_uint8):
     RESERVED_7 = 7
 
 
-class ErrorCode(t.MissingEnumMixin, t.enum_uint8):
+class ErrorCode(t.enum8):
     """Error code."""
 
     INVALID_SUBSYSTEM = 0x01
@@ -35,7 +35,7 @@ class ErrorCode(t.MissingEnumMixin, t.enum_uint8):
     INVALID_LENGTH = 0x04
 
 
-class Subsystem(t.enum_uint8):
+class Subsystem(t.enum8):
     """Command subsystem."""
 
     RPCError = 0x00
@@ -72,7 +72,7 @@ class Subsystem(t.enum_uint8):
     RESERVED_31 = 0x1F
 
 
-class CallbackSubsystem(t.enum_uint16):
+class CallbackSubsystem(t.enum16):
     """Subscribe/unsubscribe subsystem callbacks."""
 
     MT_SYS = Subsystem.SYS << 8
@@ -508,7 +508,7 @@ class CommandBase:
     __str__ = __repr__
 
 
-class DeviceState(t.enum_uint8):
+class DeviceState(t.enum8):
     """Indicated device state."""
 
     # Initialized - not started automatically
@@ -545,7 +545,7 @@ class DeviceState(t.enum_uint8):
     RejoinInsecureScanningAllChannels = 0x0F
 
 
-class InterPanCommand(t.enum_uint8):
+class InterPanCommand(t.enum8):
     # Switch channel back to the NIB channel
     Clr = 0x00
     # Set channel for inter-pan communication
@@ -556,7 +556,7 @@ class InterPanCommand(t.enum_uint8):
     Chk = 0x03
 
 
-class MTCapabilities(t.enum_flag_uint16):
+class MTCapabilities(t.bitmap16):
     SYS = 1 << 0
     MAC = 1 << 1
     NWK = 1 << 2

--- a/zigpy_znp/types/cstruct.py
+++ b/zigpy_znp/types/cstruct.py
@@ -24,7 +24,8 @@ class CStructField:
         self.get_size_and_alignment()
 
     def get_size_and_alignment(self, align=False) -> tuple[int, int]:
-        if issubclass(self.type, (zigpy_t.FixedIntType, t.FixedIntType)):
+        if issubclass(self.type, zigpy_t.FixedIntType):
+            assert self.type._size is not None
             return self.type._size, (self.type._size if align else 1)
         elif issubclass(self.type, zigpy_t.EUI64):
             return 8, 1

--- a/zigpy_znp/types/named.py
+++ b/zigpy_znp/types/named.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import sys
+import enum
 import typing
 import logging
 import dataclasses
@@ -15,8 +15,10 @@ LOGGER = logging.getLogger(__name__)
 JSONType = typing.Dict[str, typing.Any]
 
 
-class AddrMode(basic.enum_uint8):
+class AddrMode(basic.enum8):
     """Address mode."""
+
+    _missing_ = enum.Enum._missing_  # There are no missing members
 
     NOT_PRESENT = 0x00
     Group = 0x01
@@ -49,13 +51,13 @@ class AddrModeAddress:
         cls, zigpy_addr: zigpy.types.AddrModeAddress
     ) -> AddrModeAddress:
         return cls(
-            mode=AddrMode[zigpy_addr.addr_mode.name],
+            mode=AddrMode[zigpy_addr.addr_mode.name],  # type: ignore[misc]
             address=zigpy_addr.address,
         )
 
     def as_zigpy_type(self) -> zigpy.types.AddrModeAddress:
         return zigpy.types.AddrModeAddress(
-            addr_mode=zigpy.types.AddrMode[self.mode.name],
+            addr_mode=zigpy.types.AddrMode[self.mode.name],  # type: ignore[misc]
             address=self.address,
         )
 
@@ -97,11 +99,11 @@ class AddrModeAddress:
         return f"{type(self).__name__}(mode={self.mode!r}, address={self.address!r})"
 
 
-class GroupId(basic.uint16_t, hex_repr=True):
+class GroupId(basic.uint16_t, repr="hex"):  # type: ignore[call-arg]
     """Group ID class"""
 
 
-class ScanType(basic.enum_uint8):
+class ScanType(basic.enum8):
     EnergyDetect = 0x00
     Active = 0x01
     Passive = 0x02
@@ -118,28 +120,7 @@ class Param:
     optional: bool = False
 
 
-class MissingEnumMixin:
-    @classmethod
-    def _missing_(cls, value):
-        if not isinstance(value, int):
-            raise ValueError(f"{value} is not a valid {cls.__name__}")
-
-        new_member = cls._member_type_.__new__(cls, value)
-        new_member._name_ = f"unknown_0x{value:02X}"
-        new_member._value_ = cls._member_type_(value)
-
-        if sys.version_info >= (3, 8):
-            # Show the warning in the calling code, not in this function
-            LOGGER.warning(
-                "Unhandled %s value: %s", cls.__name__, new_member, stacklevel=2
-            )
-        else:
-            LOGGER.warning("Unhandled %s value: %s", cls.__name__, new_member)
-
-        return new_member
-
-
-class Status(MissingEnumMixin, basic.enum_uint8):
+class Status(basic.enum8):
     SUCCESS = 0x00
     FAILURE = 0x01
     INVALID_PARAMETER = 0x02
@@ -349,13 +330,13 @@ class Status(MissingEnumMixin, basic.enum_uint8):
     MAC_AUTOACK_PENDING_ALL_OFF = 0xFF
 
 
-class ResetReason(basic.enum_uint8):
+class ResetReason(basic.enum8):
     PowerUp = 0x00
     External = 0x01
     Watchdog = 0x02
 
 
-class ResetType(basic.enum_uint8):
+class ResetType(basic.enum8):
     Hard = 0x00
     Soft = 0x01
     Shutdown = 0x02
@@ -365,7 +346,7 @@ class KeySource(basic.FixedList, item_type=basic.uint8_t, length=8):
     pass
 
 
-class StartupOptions(basic.enum_flag_uint8):
+class StartupOptions(basic.bitmap8):
     NONE = 0
 
     ClearConfig = 1 << 0
@@ -378,13 +359,13 @@ class StartupOptions(basic.enum_flag_uint8):
     ClearNwkFrameCounter = 1 << 7
 
 
-class DeviceLogicalType(basic.enum_uint8):
+class DeviceLogicalType(basic.enum8):
     Coordinator = 0
     Router = 1
     EndDevice = 2
 
 
-class DeviceTypeCapabilities(basic.enum_flag_uint8):
+class DeviceTypeCapabilities(basic.bitmap8):
     Coordinator = 1 << 0
     Router = 1 << 1
     EndDevice = 1 << 2
@@ -400,7 +381,7 @@ class NWKList(basic.LVList, item_type=zigpy_types.NWK, length_type=basic.uint8_t
     pass
 
 
-class NwkMode(basic.enum_uint8):
+class NwkMode(basic.enum8):
     Star = 0
     Tree = 1
     Mesh = 2

--- a/zigpy_znp/types/named.py
+++ b/zigpy_znp/types/named.py
@@ -51,13 +51,13 @@ class AddrModeAddress:
         cls, zigpy_addr: zigpy.types.AddrModeAddress
     ) -> AddrModeAddress:
         return cls(
-            mode=AddrMode[zigpy_addr.addr_mode.name],  # type: ignore[misc]
+            mode=AddrMode[zigpy_addr.addr_mode.name],
             address=zigpy_addr.address,
         )
 
     def as_zigpy_type(self) -> zigpy.types.AddrModeAddress:
         return zigpy.types.AddrModeAddress(
-            addr_mode=zigpy.types.AddrMode[self.mode.name],  # type: ignore[misc]
+            addr_mode=zigpy.types.AddrMode[self.mode.name],
             address=self.address,
         )
 

--- a/zigpy_znp/types/nvids.py
+++ b/zigpy_znp/types/nvids.py
@@ -1,7 +1,7 @@
 import zigpy_znp.types as t
 
 
-class BaseNvIds(t.enum_uint16):
+class BaseNvIds(t.enum16):
     pass
 
 
@@ -12,7 +12,7 @@ class ZclPortNvIds(BaseNvIds):
     SINK_TABLE = 0x0003
 
 
-class NvSysIds(t.enum_uint8):
+class NvSysIds(t.enum8):
     NVDRVR = 0  # Refrain from use
     ZSTACK = 1
     TIMAC = 2

--- a/zigpy_znp/types/structs.py
+++ b/zigpy_znp/types/structs.py
@@ -1,4 +1,4 @@
-from . import basic, named, cstruct, zigpy_types
+from . import basic, cstruct, zigpy_types
 
 
 class NwkKeyDesc(cstruct.CStruct):
@@ -6,7 +6,7 @@ class NwkKeyDesc(cstruct.CStruct):
     Key: zigpy_types.KeyData
 
 
-class NwkState(basic.enum_uint8):
+class NwkState(basic.enum8):
     NWK_INIT = 0
     NWK_JOINING_ORPHAN = 1
     NWK_DISC = 2
@@ -120,7 +120,7 @@ class NwkActiveKeyItems(cstruct.CStruct):
     FrameCounter: basic.uint32_t
 
 
-class KeyType(named.MissingEnumMixin, basic.enum_uint8):
+class KeyType(basic.enum8):
     NONE = 0
 
     # Standard Network Key
@@ -136,7 +136,7 @@ class KeyType(named.MissingEnumMixin, basic.enum_uint8):
     UNKNOWN_6 = 6
 
 
-class KeyAttributes(basic.enum_uint8):
+class KeyAttributes(basic.enum8):
     # Used for IC derived keys
     PROVISIONAL_KEY = 0x00
     # Unique key that is not verified
@@ -177,7 +177,7 @@ class NwkSecMaterialDesc(cstruct.CStruct):
     ExtendedPanID: zigpy_types.EUI64
 
 
-class AddrMgrUserType(basic.enum_flag_uint8):
+class AddrMgrUserType(basic.bitmap8):
     Default = 0x00
     Assoc = 0x01
     Security = 0x02
@@ -195,7 +195,7 @@ class AddressManagerTable(basic.CompleteList, item_type=AddrMgrEntry):
     pass
 
 
-class AuthenticationOption(basic.enum_uint8):
+class AuthenticationOption(basic.enum8):
     NotAuthenticated = 0x00
     AuthenticatedCBCK = 0x01
     AuthenticatedEA = 0x02

--- a/zigpy_znp/zigbee/application.py
+++ b/zigpy_znp/zigbee/application.py
@@ -68,7 +68,7 @@ REQUEST_RETRYABLE_ERRORS = REQUEST_TRANSIENT_ERRORS | REQUEST_ROUTING_ERRORS
 LOGGER = logging.getLogger(__name__)
 
 
-class RetryMethod(t.enum_flag_uint8):
+class RetryMethod(t.bitmap8):
     NONE = 0
     AssocRemove = 2 << 0
     RouteDiscovery = 2 << 1


### PR DESCRIPTION
Zigpy's types at this point have feature parity with zigpy-znp's so it's time to merge the two. This will also allow `enum` module breaking changes to be handled in a single place.