### PR TITLE
Fail all pending requests during a reset

### DIFF
--- a/zigpy_znp/exceptions.py
+++ b/zigpy_znp/exceptions.py
@@ -13,6 +13,10 @@ class CommandNotRecognized(Exception):
     pass
 
 
+class ControllerResetting(Exception):
+    pass
+
+
 class InvalidCommandResponse(DeliveryError):
     def __init__(self, message, response):
         super().__init__(message)

--- a/zigpy_znp/zigbee/application.py
+++ b/zigpy_znp/zigbee/application.py
@@ -25,7 +25,11 @@ import zigpy_znp.config as conf
 import zigpy_znp.commands as c
 from zigpy_znp.api import ZNP
 from zigpy_znp.utils import combine_concurrent_calls
-from zigpy_znp.exceptions import CommandNotRecognized, InvalidCommandResponse
+from zigpy_znp.exceptions import (
+    ControllerResetting,
+    CommandNotRecognized,
+    InvalidCommandResponse,
+)
 from zigpy_znp.types.nvids import OsalNvIds
 from zigpy_znp.zigbee.device import ZNPCoordinator
 
@@ -687,6 +691,8 @@ class ControllerApplication(zigpy.application.ControllerApplication):
 
             try:
                 await self._znp.request(c.SYS.Ping.Req())
+            except ControllerResetting:
+                LOGGER.debug("Controller is resetting, ignoring watchdog failure")
             except Exception as e:
                 LOGGER.error(
                     "Watchdog check failed",


### PR DESCRIPTION
If the serial link is slow enough (i.e. a TCP coordinator), it appears that a race condition can arise where a watchdog poll can coincide with an intentional reset request. During a reset, all pending requests should be cancelled.

CC @tube0013