### PR TITLE
Fix ZGP handling in ZNP

### DIFF
--- a/zigpy_znp/commands/zdo.py
+++ b/zigpy_znp/commands/zdo.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import zigpy.zdo.types
 
 import zigpy_znp.types as t
-
+import zigpy.types
 
 class SecurityEntry(t.FixedList, item_type=t.uint8_t, length=5):
     pass
@@ -797,10 +797,10 @@ class ZDO(t.CommandsBase, subsystem=t.Subsystem.ZDO):
         0x49,
         req_schema=(
             t.Param("Endpoint", t.uint8_t, "Endpoint to look for"),
-            # this parameter does not make sense
-            t.Param("Groups", t.uint16_t, "List to hold group IDs"),
         ),
-        rsp_schema=(t.Param("Groups", GroupIdList, "List of Group IDs"),),
+        rsp_schema=(
+            t.Param("Groups", GroupIdList, "List of Group IDs"),
+        ),
     )
 
     # handle the ZDO extension find group message
@@ -811,7 +811,11 @@ class ZDO(t.CommandsBase, subsystem=t.Subsystem.ZDO):
             t.Param("Endpoint", t.uint8_t, "Endpoint to look for"),
             t.Param("GroupId", t.GroupId, "ID to look for group"),
         ),
-        rsp_schema=(t.Param("Group", t.Bytes, "Group information"),),
+        rsp_schema=(
+            t.Param("Status", t.Status, "Status is either Success (0) or Failure (1)"),
+            t.Param("GroupId", zigpy.types.uint16_t, "Found Group ID"),
+            t.Param("GroupName", t.CharacterString, "Group name"),
+        ),
     )
 
     # handle the ZDO extension add group message

--- a/zigpy_znp/commands/zdo.py
+++ b/zigpy_znp/commands/zdo.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import zigpy.zdo.types
 
 import zigpy_znp.types as t
-import zigpy.types
 
 class SecurityEntry(t.FixedList, item_type=t.uint8_t, length=5):
     pass
@@ -813,8 +812,8 @@ class ZDO(t.CommandsBase, subsystem=t.Subsystem.ZDO):
         ),
         rsp_schema=(
             t.Param("Status", t.Status, "Status is either Success (0) or Failure (1)"),
-            t.Param("GroupId", zigpy.types.uint16_t, "Found Group ID"),
-            t.Param("GroupName", t.CharacterString, "Group name"),
+            t.Param("GroupId", t.GroupId, "Found Group ID"),
+            t.Param("GroupName", t.Bytes, "Group name"),
         ),
     )
 

--- a/zigpy_znp/commands/zgp.py
+++ b/zigpy_znp/commands/zgp.py
@@ -97,7 +97,7 @@ class ZGP(t.CommandsBase, subsystem=t.Subsystem.ZGP):
     # This message provides a mechanism for dGP stub to request security data from the
     # Green Power EndPoint in the host processor
     SecReq = t.CommandDef(
-        t.CommandType.AREQ,
+        t.CommandType.SREQ,
         0x03,
         req_schema=(
             t.Param(
@@ -127,6 +127,7 @@ class ZGP(t.CommandsBase, subsystem=t.Subsystem.ZGP):
                 "Handle", t.uint8_t, "dGP stub handle to match req to confirmation"
             ),
         ),
+        rsp_schema=t.STATUS_SCHEMA,
     )
 
     # This message provides a mechanism for identifying and conveying a received
@@ -134,7 +135,7 @@ class ZGP(t.CommandsBase, subsystem=t.Subsystem.ZGP):
     DataInd = t.CommandDef(
         t.CommandType.AREQ,
         0x04,
-        req_schema=(
+        rsp_schema=(
             t.Param("Status", t.uint8_t, "The status code as returned by the dGP stub"),
             t.Param(
                 "RSSI",

--- a/zigpy_znp/zigbee/application.py
+++ b/zigpy_znp/zigbee/application.py
@@ -416,6 +416,14 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             self.on_intentionally_unhandled_message,
         )
 
+        self._znp.callback_for_response(
+            c.ZGP.DataInd.Callback(partial=True),
+            self.on_zgp_data_ind
+        )
+
+    def on_zgp_data_ind(self, msg: c.ZGP.DataInd.Callback) -> None:
+        pass
+
     def on_intentionally_unhandled_message(self, msg: t.CommandBase) -> None:
         """
         Some commands are unhandled but frequently sent by devices on the network. To
@@ -691,6 +699,9 @@ class ControllerApplication(zigpy.application.ControllerApplication):
 
         if dst_ep == ZDO_ENDPOINT:
             return ZDO_ENDPOINT
+        
+        if profile == zigpy.profiles.zgp.PROFILE_ID:
+            return zigpy.profiles.zgp.GREENPOWER_ENDPOINT_ID
 
         # Newer Z-Stack releases ignore profiles and will work properly with endpoint 1
         if (

--- a/zigpy_znp/zigbee/device.py
+++ b/zigpy_znp/zigbee/device.py
@@ -1,19 +1,49 @@
 from __future__ import annotations
 
 import logging
+from typing import Any, Coroutine
+from zigpy.zcl.foundation import Status as ZCLStatus, Status
 
 import zigpy.zdo
+import zigpy.endpoint
 import zigpy.device
 import zigpy.application
+from zigpy_znp.api import ZNP
+import zigpy_znp.commands as c
+import zigpy_znp.types as t
 
 LOGGER = logging.getLogger(__name__)
 
+class ZNPEndpoint(zigpy.endpoint.Endpoint):
+    async def add_to_group(self, grp_id: int, name: str | None = None) -> ZCLStatus:
+        znp: ZNP = self.device.application._znp
+        if name is None:
+            name = ""
 
+        result = await znp.request(c.ZDO.ExtFindGroup.Req(Endpoint=self.endpoint_id, GroupId=grp_id))
+        if result.Status == t.Status.FAILURE:
+            result = await znp.request(c.ZDO.ExtAddGroup.Req(Endpoint=self.endpoint_id, GroupId=grp_id, GroupName=t.CharacterString(name)))
+        if result.Status == t.Status.SUCCESS:
+            group = self.device.application.groups.add_group(grp_id, name)
+            group.add_member(self)
+            return ZCLStatus.SUCCESS
+        return ZCLStatus.FAILURE
+        
+    
+    async def remove_from_group(self, grp_id: int) -> ZCLStatus:
+        znp: ZNP = self.device.application._znp
+        result = await znp.request(c.ZDO.ExtRemoveGroup.Req(Endpoint=self.endpoint_id, GroupId=grp_id))
+        if grp_id in self.device.application.groups:
+            self.device.application.groups[grp_id].remove_member(self)
+        if result.Status == t.Status.FAILURE:
+            return ZCLStatus.FAILURE
+        return ZCLStatus.SUCCESS
+
+    
 class ZNPCoordinator(zigpy.device.Device):
     """
     Coordinator zigpy device that keeps track of our endpoints and clusters.
     """
-
     @property
     def manufacturer(self):
         return "Texas Instruments"
@@ -21,6 +51,11 @@ class ZNPCoordinator(zigpy.device.Device):
     @property
     def model(self):
         return "Coordinator"
+
+    def add_endpoint(self, endpoint_id) -> zigpy.endpoint.Endpoint:
+        ep = ZNPEndpoint(self, endpoint_id)
+        self.endpoints[endpoint_id] = ep
+        return ep
 
     def request(
         self,

--- a/zigpy_znp/zigbee/device.py
+++ b/zigpy_znp/zigbee/device.py
@@ -23,20 +23,19 @@ class ZNPEndpoint(zigpy.endpoint.Endpoint):
         result = await znp.request(c.ZDO.ExtFindGroup.Req(Endpoint=self.endpoint_id, GroupId=grp_id))
         if result.Status == t.Status.FAILURE:
             result = await znp.request(c.ZDO.ExtAddGroup.Req(Endpoint=self.endpoint_id, GroupId=grp_id, GroupName=t.CharacterString(name)))
-        if result.Status == t.Status.SUCCESS:
-            group = self.device.application.groups.add_group(grp_id, name)
-            group.add_member(self)
-            return ZCLStatus.SUCCESS
-        return ZCLStatus.FAILURE
+        if result.Status == t.Status.FAILURE:
+            return ZCLStatus.FAILURE
+        group = self.device.application.groups.add_group(grp_id, name)
+        group.add_member(self)
+        return ZCLStatus.SUCCESS
         
-    
     async def remove_from_group(self, grp_id: int) -> ZCLStatus:
         znp: ZNP = self.device.application._znp
         result = await znp.request(c.ZDO.ExtRemoveGroup.Req(Endpoint=self.endpoint_id, GroupId=grp_id))
-        if grp_id in self.device.application.groups:
-            self.device.application.groups[grp_id].remove_member(self)
         if result.Status == t.Status.FAILURE:
             return ZCLStatus.FAILURE
+        if grp_id in self.device.application.groups:
+            self.device.application.groups[grp_id].remove_member(self)
         return ZCLStatus.SUCCESS
 
     


### PR DESCRIPTION
Make sure that application device endpoints properly subscribe to groups, ensure that profile ID's are respected on the GP endpoints, and make sure that all ZGP requests are sent with the correct profiles.