### PR TITLE
Fix ZGP profile and endpoint handling

### DIFF
--- a/zigpy_znp/zigbee/application.py
+++ b/zigpy_znp/zigbee/application.py
@@ -691,7 +691,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
 
         if dst_ep == ZDO_ENDPOINT:
             return ZDO_ENDPOINT
-        
+
         if profile == zigpy.profiles.zgp.PROFILE_ID:
             return zigpy.profiles.zgp.GREENPOWER_ENDPOINT_ID
 

--- a/zigpy_znp/zigbee/application.py
+++ b/zigpy_znp/zigbee/application.py
@@ -691,6 +691,9 @@ class ControllerApplication(zigpy.application.ControllerApplication):
 
         if dst_ep == ZDO_ENDPOINT:
             return ZDO_ENDPOINT
+        
+        if profile == zigpy.profiles.zgp.PROFILE_ID:
+            return zigpy.profiles.zgp.GREENPOWER_ENDPOINT_ID
 
         # Newer Z-Stack releases ignore profiles and will work properly with endpoint 1
         if (


### PR DESCRIPTION
Always ensure that ZGP profile packets end up on the ZGP endpoint, preserving the profile ID to boot.