### PR TITLE
Implement command priority

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 license = {text = "GPL-3.0"}
 requires-python = ">=3.8"
 dependencies = [
-    "zigpy>=0.60.0",
+    "zigpy>=0.60.2",
     "async_timeout",
     "voluptuous",
     "coloredlogs",


### PR DESCRIPTION
https://github.com/zigpy/zigpy/pull/1297

ZNP doesn't actually need this change, as commands are not synchronous in Z-Stack and follow a "request/response/callback" system where the "request/response" phase is nearly instant and the lock will probably never actually be hit.