### PR TITLE
Use explicit exceptions when cancelling listeners

### DIFF
--- a/zigpy_znp/api.py
+++ b/zigpy_znp/api.py
@@ -32,7 +32,11 @@ from zigpy_znp.utils import (
     CallbackResponseListener,
 )
 from zigpy_znp.frames import GeneralFrame
-from zigpy_znp.exceptions import CommandNotRecognized, InvalidCommandResponse
+from zigpy_znp.exceptions import (
+    ShuttingDown,
+    CommandNotRecognized,
+    InvalidCommandResponse,
+)
 from zigpy_znp.types.nvids import ExNvIds, OsalNvIds
 
 if typing.TYPE_CHECKING:
@@ -774,7 +778,7 @@ class ZNP:
 
         for _header, listeners in self._listeners.items():
             for listener in listeners:
-                listener.cancel()
+                listener.set_exception(ShuttingDown())
 
         self._listeners.clear()
         self.version = None

--- a/zigpy_znp/exceptions.py
+++ b/zigpy_znp/exceptions.py
@@ -1,4 +1,4 @@
-from zigpy.exceptions import DeliveryError
+from zigpy.exceptions import DeliveryError, ControllerException
 
 
 class InvalidFrame(ValueError):
@@ -17,3 +17,7 @@ class InvalidCommandResponse(DeliveryError):
     def __init__(self, message, response):
         super().__init__(message)
         self.response = response
+
+
+class ShuttingDown(ControllerException):
+    pass

--- a/zigpy_znp/utils.py
+++ b/zigpy_znp/utils.py
@@ -86,7 +86,7 @@ class BaseResponseListener:
 
         raise NotImplementedError()  # pragma: no cover
 
-    def cancel(self):
+    def set_exception(self, exc: BaseException) -> None:
         """
         Implement by subclasses to cancel the listener.
 
@@ -118,11 +118,9 @@ class OneShotResponseListener(BaseResponseListener):
         self.future.set_result(response)
         return True
 
-    def cancel(self):
+    def set_exception(self, exc: BaseException) -> None:
         if not self.future.done():
-            self.future.cancel()
-
-        return True
+            self.future.set_exception(exc)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -149,9 +147,9 @@ class CallbackResponseListener(BaseResponseListener):
         # Callbacks are always resolved
         return True
 
-    def cancel(self):
+    def set_exception(self, exc: BaseException) -> None:
         # You can't cancel a callback
-        return False
+        pass
 
 
 class CatchAllResponse:


### PR DESCRIPTION
Propagating `asyncio.CancelledError` breaks regular exception handling. We should avoid doing so.