### PR TITLE
Fix tests broken by zigpy update

### DIFF
--- a/tests/application/test_connect.py
+++ b/tests/application/test_connect.py
@@ -203,11 +203,10 @@ async def test_disconnect_failure(device, make_application):
 @pytest.mark.parametrize("device", [FormedLaunchpadCC26X2R1])
 async def test_watchdog(device, make_application):
     app, znp_server = make_application(server_cls=device)
-    await app.startup(auto_form=False)
-
     app._watchdog_feed = AsyncMock(wraps=app._watchdog_feed)
 
     with patch("zigpy.application.ControllerApplication._watchdog_period", new=0.1):
+        await app.startup(auto_form=False)
         await asyncio.sleep(0.6)
 
     assert len(app._watchdog_feed.mock_calls) >= 5

--- a/tests/application/test_connect.py
+++ b/tests/application/test_connect.py
@@ -1,4 +1,3 @@
-import asyncio
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -201,14 +200,12 @@ async def test_disconnect_failure(device, make_application):
 
 
 @pytest.mark.parametrize("device", [FormedLaunchpadCC26X2R1])
+@patch("zigpy_znp.zigbee.application.ControllerApplication._watchdog_period", new=0.1)
 async def test_watchdog(device, make_application):
     app, znp_server = make_application(server_cls=device)
     app._watchdog_feed = AsyncMock(wraps=app._watchdog_feed)
 
-    with patch("zigpy.application.ControllerApplication._watchdog_period", new=0.1):
-        await app.startup(auto_form=False)
-        await asyncio.sleep(0.6)
-
+    await app.startup(auto_form=False)
     assert len(app._watchdog_feed.mock_calls) >= 5
 
     await app.shutdown()

--- a/tests/application/test_connect.py
+++ b/tests/application/test_connect.py
@@ -1,3 +1,4 @@
+import asyncio
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -206,6 +207,7 @@ async def test_watchdog(device, make_application):
     app._watchdog_feed = AsyncMock(wraps=app._watchdog_feed)
 
     await app.startup(auto_form=False)
+    await asyncio.sleep(0.6)
     assert len(app._watchdog_feed.mock_calls) >= 5
 
     await app.shutdown()

--- a/tests/application/test_joining.py
+++ b/tests/application/test_joining.py
@@ -40,7 +40,7 @@ async def test_permit_join(device, mocker, make_application):
         request=zdo_request_matcher(
             dst_addr=t.AddrModeAddress(t.AddrMode.Broadcast, 0xFFFC),
             command_id=zdo_t.ZDOCmd.Mgmt_Permit_Joining_req,
-            TSN=7,
+            TSN=2,
             zdo_PermitDuration=10,
             zdo_TC_Significant=0,
         ),
@@ -117,7 +117,7 @@ async def test_join_device(device, make_application):
                 IsBroadcast=t.Bool.false,
                 ClusterId=32822,
                 SecurityUse=0,
-                TSN=7,
+                TSN=1,
                 MacDst=0x0000,
                 Data=b"\x00",
             ),

--- a/tests/application/test_requests.py
+++ b/tests/application/test_requests.py
@@ -51,7 +51,7 @@ async def test_zigpy_request(device, make_application):
     app, znp_server = make_application(device)
     await app.startup(auto_form=False)
 
-    TSN = 7
+    TSN = 1
 
     device = app.add_initialized_device(ieee=t.EUI64(range(8)), nwk=0xAABB)
 
@@ -111,7 +111,7 @@ async def test_zigpy_request_failure(device, make_application, mocker):
     app, znp_server = make_application(device)
     await app.startup(auto_form=False)
 
-    TSN = 7
+    TSN = 1
 
     device = app.add_initialized_device(ieee=t.EUI64(range(8)), nwk=0xAABB)
 
@@ -456,7 +456,7 @@ async def test_request_cancellation_shielding(
 
 @pytest.mark.parametrize("device", [FormedLaunchpadCC26X2R1])
 async def test_request_recovery_route_rediscovery_zdo(device, make_application, mocker):
-    TSN = 7
+    TSN = 1
 
     app, znp_server = make_application(server_cls=device)
 


### PR DESCRIPTION
This fixes tests that were broken by [zigpy 0.60.3](https://github.com/zigpy/zigpy/releases/tag/0.60.3) (and later).

- the TSNs are changed because of https://github.com/zigpy/zigpy/pull/1309
- the watchdog loop is now started earlier because of https://github.com/zigpy/zigpy/pull/1308


For the watchdog change, we can also only move the startup phase (where the watchdog loop gets started) into where the period is patched: https://github.com/zigpy/zigpy-znp/commit/464a9fffc8b2db54cc3ea230496ba8896364433a, but we might as well patch the period for the entire test (which I did for now). Or is there another preferred way to do it?

cc @puddly

Depending on how GitHub actions work, we might want to merge https://github.com/zigpy/zigpy-znp/pull/245 first to have CI working.
EDIT: Yeah, looks like CI doesn't start at all, so am I fine to merge that Codecov CI first?