### PR TITLE
Fix blocking metadata version call

### DIFF
--- a/zigpy_znp/api.py
+++ b/zigpy_znp/api.py
@@ -38,6 +38,7 @@ from zigpy_znp.types.nvids import ExNvIds, OsalNvIds
 if typing.TYPE_CHECKING:
     import typing_extensions
 
+LIB_VERSION = importlib.metadata.version("zigpy-znp")
 LOGGER = logging.getLogger(__name__)
 
 
@@ -148,7 +149,7 @@ class ZNP:
         )
 
         network_info = zigpy.state.NetworkInfo(
-            source=f"zigpy-znp@{importlib.metadata.version('zigpy-znp')}",
+            source=f"zigpy-znp@{LIB_VERSION}",
             extended_pan_id=nib.extendedPANID,
             pan_id=nib.nwkPanId,
             nwk_update_id=nib.nwkUpdateId,

--- a/zigpy_znp/tools/network_backup.py
+++ b/zigpy_znp/tools/network_backup.py
@@ -14,6 +14,7 @@ from zigpy_znp.api import ZNP
 from zigpy_znp.tools.common import ClosableFileType, setup_parser, validate_backup_json
 from zigpy_znp.zigbee.application import ControllerApplication
 
+LIB_VERSION = importlib.metadata.version("zigpy-znp")
 LOGGER = logging.getLogger(__name__)
 
 
@@ -84,7 +85,7 @@ async def backup_network(znp: ZNP) -> t.JSONType:
 
     now = datetime.datetime.now().astimezone()
 
-    obj["metadata"]["source"] = f"zigpy-znp@{importlib.metadata.version('zigpy-znp')}"
+    obj["metadata"]["source"] = f"zigpy-znp@{LIB_VERSION}"
     obj["metadata"]["internal"] = {
         "creation_time": now.isoformat(timespec="seconds"),
         "zstack": {


### PR DESCRIPTION
This moves the blocking metadata version call outside of the load_network_info coroutine that's run at startup.
And it's also a good test run to see if tests are still working with the latest zigpy.