### PR TITLE
Disable skip_bootloader when the config is set to False

### DIFF
--- a/zigpy_znp/api.py
+++ b/zigpy_znp/api.py
@@ -734,7 +734,12 @@ class ZNP:
             # prevent any data from being sent
             if test_port:
                 # The reset indication callback is sent when some sticks start up
-                self.capabilities = (await self._skip_bootloader()).Capabilities
+                if self._znp_config[conf.CONF_SKIP_BOOTLOADER]:
+                    self.capabilities = (await self._skip_bootloader()).Capabilities
+                else:
+                    self.capabilities = (
+                        await self.request(c.SYS.Ping.Req())
+                    ).Capabilities
 
                 # We need to know how structs are packed to deserialize frames correctly
                 await self.nvram.determine_alignment()


### PR DESCRIPTION
On SMLIGHT SLZB-06 devices in USB mode the skip bootloader sequence causes the esp32 in these devices to reset.

While there is a config option to disable skip bootloader, it is not hooked up.

Ensure that it is possible to disable skip bootloader.

\- @darkxst