### PR TITLE
Ignore `Binding` entries when creating a backup

### DIFF
--- a/zigpy_znp/znp/security.py
+++ b/zigpy_znp/znp/security.py
@@ -266,7 +266,10 @@ async def read_devices(
             t.EUI64.convert("FF:FF:FF:FF:FF:FF:FF:FF"),
         ):
             continue
-        elif entry.type == t.AddrMgrUserType.Default:
+        elif entry.type in (
+            t.AddrMgrUserType.Default,
+            t.AddrMgrUserType.Binding,
+        ):
             continue
         elif entry.type in (
             t.AddrMgrUserType.Assoc,


### PR DESCRIPTION
Fixes https://github.com/zigpy/zigpy-znp/issues/254