### PR TITLE
Remove 5s probe timeout

### DIFF
--- a/tests/application/test_connect.py
+++ b/tests/application/test_connect.py
@@ -76,24 +76,6 @@ async def test_probe_unsuccessful_slow1(device, make_znp_server, mocker):
 
 
 @pytest.mark.parametrize("device", FORMED_DEVICES)
-async def test_probe_unsuccessful_slow2(device, make_znp_server, mocker):
-    znp_server = make_znp_server(server_cls=device, shorten_delays=False)
-
-    # Don't respond to anything
-    znp_server._listeners.clear()
-
-    mocker.patch("zigpy_znp.zigbee.application.PROBE_TIMEOUT", new=0.1)
-
-    assert not (
-        await ControllerApplication.probe(
-            conf.SCHEMA_DEVICE({conf.CONF_DEVICE_PATH: znp_server.serial_port})
-        )
-    )
-
-    assert not any([t._is_connected for t in znp_server._transports])
-
-
-@pytest.mark.parametrize("device", FORMED_DEVICES)
 async def test_probe_successful(device, make_znp_server):
     znp_server = make_znp_server(server_cls=device, shorten_delays=False)
 

--- a/zigpy_znp/zigbee/application.py
+++ b/zigpy_znp/zigbee/application.py
@@ -39,7 +39,6 @@ ZHA_ENDPOINT = 1
 ZDO_PROFILE = 0x0000
 
 # All of these are in seconds
-PROBE_TIMEOUT = 5
 STARTUP_TIMEOUT = 5
 DATA_CONFIRM_TIMEOUT = 8
 EXTENDED_DATA_CONFIRM_TIMEOUT = 30
@@ -66,14 +65,6 @@ class ControllerApplication(zigpy.application.ControllerApplication):
     ##################################################################
     # Implementation of the core zigpy ControllerApplication methods #
     ##################################################################
-
-    @classmethod
-    async def probe(cls, device_config):
-        try:
-            async with asyncio_timeout(PROBE_TIMEOUT):
-                return await super().probe(device_config)
-        except asyncio.TimeoutError:
-            return False
 
     async def connect(self):
         assert self._znp is None


### PR DESCRIPTION
https://github.com/home-assistant/core/issues/144976

We time out in 10s instead of 5s so it's not that big of a problem.