### PR TITLE
Bump zigpy to 1.3.0 to pull in serialx dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,10 +12,9 @@ authors = [
 ]
 readme = "README.md"
 license = {text = "GPL-3.0"}
-requires-python = ">=3.8"
+requires-python = ">=3.11"
 dependencies = [
     "zigpy>=1.3.0",
-    'async-timeout; python_version<"3.11"',
     "voluptuous",
     "coloredlogs",
     "jsonschema",
@@ -97,4 +96,4 @@ disable_error_code = [
 source = ["zigpy_znp"]
 
 [tool.pyupgrade]
-py37plus = true
+py311plus = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 license = {text = "GPL-3.0"}
 requires-python = ">=3.8"
 dependencies = [
-    "zigpy>=0.91.2",
+    "zigpy>=1.3.0",
     'async-timeout; python_version<"3.11"',
     "voluptuous",
     "coloredlogs",

--- a/tests/api/test_connect.py
+++ b/tests/api/test_connect.py
@@ -109,8 +109,11 @@ async def test_connect_skip_bootloader_rts_dtr_pins(make_znp_server, mocker):
     await znp.connect(test_port=True)
 
     serial = znp._uart._transport
-    assert serial._mock_dtr_prop.mock_calls == [call(False), call(False), call(False)]
-    assert serial._mock_rts_prop.mock_calls == [call(False), call(True), call(False)]
+    assert serial._mock_set_modem_pins.mock_calls == [
+        call(dtr=False, rts=False),
+        call(dtr=False, rts=True),
+        call(dtr=False, rts=False),
+    ]
 
     await znp.disconnect()
 
@@ -130,8 +133,7 @@ async def test_connect_skip_bootloader_config(make_znp_server, mocker):
     await znp.connect(test_port=True)
 
     serial = znp._uart._transport
-    assert serial._mock_dtr_prop.called is False
-    assert serial._mock_rts_prop.called is False
+    assert len(serial._mock_set_modem_pins.mock_calls) == 0
 
     await znp.disconnect()
 

--- a/tests/api/test_request.py
+++ b/tests/api/test_request.py
@@ -1,13 +1,7 @@
-import sys
 import asyncio
 import logging
 
 import pytest
-
-if sys.version_info[:2] < (3, 11):
-    from async_timeout import timeout as asyncio_timeout  # pragma: no cover
-else:
-    from asyncio import timeout as asyncio_timeout  # pragma: no cover
 
 import zigpy_znp.types as t
 import zigpy_znp.config as conf
@@ -71,7 +65,7 @@ async def test_cleanup_timeout_external(connected_znp):
 
     # This request will timeout because we didn't send anything back
     with pytest.raises(asyncio.TimeoutError):
-        async with asyncio_timeout(0.1):
+        async with asyncio.timeout(0.1):
             await znp.request(c.UTIL.TimeAlive.Req())
 
     # We should be cleaned up
@@ -85,7 +79,7 @@ async def test_callback_rsp_cleanup_timeout_external(connected_znp):
 
     # This request will timeout because we didn't send anything back
     with pytest.raises(asyncio.TimeoutError):
-        async with asyncio_timeout(0.1):
+        async with asyncio.timeout(0.1):
             await znp.request_callback_rsp(
                 request=c.UTIL.TimeAlive.Req(),
                 callback=c.SYS.ResetInd.Callback(partial=True),
@@ -267,7 +261,7 @@ async def test_znp_sreq_srsp(connected_znp):
 
     # Each SREQ must have a corresponding SRSP, so this will fail
     with pytest.raises(asyncio.TimeoutError):
-        async with asyncio_timeout(0.5):
+        async with asyncio.timeout(0.5):
             await znp.request(c.SYS.Ping.Req())
 
     # This will work

--- a/tests/api/test_response.py
+++ b/tests/api/test_response.py
@@ -1,12 +1,6 @@
-import sys
 import asyncio
 
 import pytest
-
-if sys.version_info[:2] < (3, 11):
-    from async_timeout import timeout as asyncio_timeout  # pragma: no cover
-else:
-    from asyncio import timeout as asyncio_timeout  # pragma: no cover
 
 import zigpy_znp.types as t
 import zigpy_znp.commands as c
@@ -66,7 +60,7 @@ async def test_response_timeouts(connected_znp):
 
     asyncio.create_task(send_soon(0.1))
 
-    async with asyncio_timeout(0.5):
+    async with asyncio.timeout(0.5):
         assert (await znp.wait_for_response(c.SYS.Ping.Rsp(partial=True))) == response
 
     # The response was successfully received so we should have no outstanding listeners
@@ -76,7 +70,7 @@ async def test_response_timeouts(connected_znp):
     asyncio.create_task(send_soon(0.6))
 
     with pytest.raises(asyncio.TimeoutError):
-        async with asyncio_timeout(0.5):
+        async with asyncio.timeout(0.5):
             assert (
                 await znp.wait_for_response(c.SYS.Ping.Rsp(partial=True))
             ) == response

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ import asyncio
 import inspect
 import logging
 import pathlib
-from unittest.mock import Mock, PropertyMock, patch
+from unittest.mock import Mock, patch
 
 import pytest
 import zigpy.types
@@ -56,8 +56,10 @@ class ForwardingSerialTransport:
         self.serial = Mock()
         self.serial.name = FAKE_SERIAL_PORT
         self.serial.baudrate = 45678
-        type(self.serial).dtr = self._mock_dtr_prop = PropertyMock(return_value=None)
-        type(self.serial).rts = self._mock_rts_prop = PropertyMock(return_value=None)
+        self._mock_set_modem_pins = Mock()
+
+    async def set_modem_pins(self, *, dtr=None, rts=None, **kwargs):
+        self._mock_set_modem_pins(dtr=dtr, rts=rts, **kwargs)
 
     def _connect(self):
         assert not self._is_connected
@@ -154,7 +156,7 @@ def make_znp_server(mocker):
             return fut
 
         mocker.patch(
-            "serial_asyncio_fast.create_serial_connection", new=passthrough_serial_conn
+            "zigpy_znp.uart.create_serial_connection", new=passthrough_serial_conn
         )
 
         # So we don't have to import it every time

--- a/tests/test_uart.py
+++ b/tests/test_uart.py
@@ -1,7 +1,6 @@
 import asyncio
 
 import pytest
-from serial_asyncio_fast import SerialTransport
 
 import zigpy_znp.types as t
 import zigpy_znp.config as conf
@@ -33,13 +32,8 @@ async def dummy_serial_conn(mocker):
 
         protocol = protocol_factory()
 
-        # Our event loop doesn't really do anything
-        loop.add_writer = lambda *args, **kwargs: None
-        loop.add_reader = lambda *args, **kwargs: None
-        loop.remove_writer = lambda *args, **kwargs: None
-        loop.remove_reader = lambda *args, **kwargs: None
-
-        transport = SerialTransport(loop, protocol, serial_interface)
+        transport = mocker.Mock()
+        transport.serial = serial_interface
 
         protocol.connection_made(transport)
 
@@ -47,7 +41,7 @@ async def dummy_serial_conn(mocker):
 
         return fut
 
-    mocker.patch("serial_asyncio_fast.create_serial_connection", new=create_serial_conn)
+    mocker.patch("zigpy_znp.uart.create_serial_connection", new=create_serial_conn)
 
     return device, serial_interface
 

--- a/zigpy_znp/api.py
+++ b/zigpy_znp/api.py
@@ -667,7 +667,7 @@ class ZNP:
                 self._znp_config[conf.CONF_CONNECT_DTR_STATES],
                 self._znp_config[conf.CONF_CONNECT_RTS_STATES],
             ):
-                self._uart.set_dtr_rts(dtr=dtr, rts=rts)
+                await self._uart.set_dtr_rts(dtr=dtr, rts=rts)
                 await asyncio.sleep(BOOTLOADER_PIN_TOGGLE_DELAY)
 
             # First, just try pinging

--- a/zigpy_znp/api.py
+++ b/zigpy_znp/api.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-import sys
 import time
 import typing
 import asyncio
@@ -13,12 +12,6 @@ import importlib.metadata
 from collections import Counter, defaultdict
 
 import zigpy.state
-
-if sys.version_info[:2] < (3, 11):
-    from async_timeout import timeout as asyncio_timeout  # pragma: no cover
-else:
-    from asyncio import timeout as asyncio_timeout  # pragma: no cover
-
 import zigpy.zdo.types as zdo_t
 import zigpy.exceptions
 from zigpy.exceptions import NetworkNotFormed
@@ -302,7 +295,7 @@ class ZNP:
                         )
 
                 # Both versions still end with this callback
-                async with asyncio_timeout(STARTUP_TIMEOUT):
+                async with asyncio.timeout(STARTUP_TIMEOUT):
                     await started_as_coordinator
             except asyncio.TimeoutError as e:
                 raise zigpy.exceptions.FormationFailure(
@@ -672,7 +665,7 @@ class ZNP:
 
             # First, just try pinging
             try:
-                async with asyncio_timeout(CONNECT_PING_TIMEOUT):
+                async with asyncio.timeout(CONNECT_PING_TIMEOUT):
                     return await self.request(c.SYS.Ping.Req())
             except asyncio.TimeoutError:
                 pass
@@ -688,7 +681,7 @@ class ZNP:
             # At this point we have nothing left to try
             while True:
                 try:
-                    async with asyncio_timeout(2 * CONNECT_PING_TIMEOUT):
+                    async with asyncio.timeout(2 * CONNECT_PING_TIMEOUT):
                         return await self.request(c.SYS.Ping.Req())
                 except asyncio.TimeoutError:
                     pass
@@ -697,7 +690,7 @@ class ZNP:
             ping_task = asyncio.create_task(ping_task())
 
             try:
-                async with asyncio_timeout(CONNECT_PROBE_TIMEOUT):
+                async with asyncio.timeout(CONNECT_PROBE_TIMEOUT):
                     result = await responses.get()
             except Exception:
                 ping_task.cancel()
@@ -712,7 +705,7 @@ class ZNP:
                 LOGGER.debug("Giving ping task %0.2fs to finish", CONNECT_PING_TIMEOUT)
 
                 try:
-                    async with asyncio_timeout(CONNECT_PING_TIMEOUT):
+                    async with asyncio.timeout(CONNECT_PING_TIMEOUT):
                         result = await ping_task  # type:ignore[misc]
                 except asyncio.TimeoutError:
                     ping_task.cancel()
@@ -1072,7 +1065,7 @@ class ZNP:
             self._uart.send(frame)
 
             # We should get a SRSP in a reasonable amount of time
-            async with asyncio_timeout(
+            async with asyncio.timeout(
                 timeout or self._znp_config[conf.CONF_SREQ_TIMEOUT]
             ):
                 # We lock until either a sync response is seen or an error occurs
@@ -1114,7 +1107,7 @@ class ZNP:
         # Typical request/response/callbacks are not backgrounded
         if not background:
             try:
-                async with asyncio_timeout(timeout):
+                async with asyncio.timeout(timeout):
                     await self.request(request, timeout=timeout, **response_params)
 
                     return await callback_rsp
@@ -1125,7 +1118,7 @@ class ZNP:
         start_time = time.monotonic()
 
         try:
-            async with asyncio_timeout(timeout):
+            async with asyncio.timeout(timeout):
                 request_rsp = await self.request(request, **response_params)
         except Exception:
             # If the SREQ/SRSP pair fails, we must cancel the AREQ listener
@@ -1137,7 +1130,7 @@ class ZNP:
         # the timeout
         async def callback_catcher(timeout):
             try:
-                async with asyncio_timeout(timeout):
+                async with asyncio.timeout(timeout):
                     await callback_rsp
             finally:
                 self.remove_listener(listener)

--- a/zigpy_znp/tools/flash_read.py
+++ b/zigpy_znp/tools/flash_read.py
@@ -2,11 +2,6 @@ import sys
 import asyncio
 import logging
 
-if sys.version_info[:2] < (3, 11):
-    from async_timeout import timeout as asyncio_timeout  # pragma: no cover
-else:
-    from asyncio import timeout as asyncio_timeout  # pragma: no cover
-
 import zigpy_znp.commands as c
 from zigpy_znp.api import ZNP
 from zigpy_znp.config import CONFIG_SCHEMA
@@ -17,7 +12,7 @@ LOGGER = logging.getLogger(__name__)
 
 async def read_firmware(znp: ZNP) -> bytearray:
     try:
-        async with asyncio_timeout(5):
+        async with asyncio.timeout(5):
             handshake_rsp = await znp.request_callback_rsp(
                 request=c.UBL.HandshakeReq.Req(),
                 callback=c.UBL.HandshakeRsp.Callback(partial=True),

--- a/zigpy_znp/tools/flash_write.py
+++ b/zigpy_znp/tools/flash_write.py
@@ -4,12 +4,6 @@ import sys
 import asyncio
 import logging
 
-if sys.version_info[:2] < (3, 11):
-    from async_timeout import timeout as asyncio_timeout  # pragma: no cover
-else:
-    from asyncio import timeout as asyncio_timeout  # pragma: no cover
-
-
 import zigpy_znp.types as t
 import zigpy_znp.commands as c
 from zigpy_znp.api import ZNP
@@ -74,7 +68,7 @@ async def write_firmware(znp: ZNP, firmware: bytes, reset_nvram: bool):
         )
 
     try:
-        async with asyncio_timeout(5):
+        async with asyncio.timeout(5):
             handshake_rsp = await znp.request_callback_rsp(
                 request=c.UBL.HandshakeReq.Req(),
                 callback=c.UBL.HandshakeRsp.Callback(partial=True),

--- a/zigpy_znp/uart.py
+++ b/zigpy_znp/uart.py
@@ -5,7 +5,7 @@ import asyncio
 import logging
 
 import zigpy.config
-import zigpy.serial
+from zigpy.serial import SerialProtocol, create_serial_connection
 
 import zigpy_znp.config as conf
 import zigpy_znp.frames as frames
@@ -20,7 +20,7 @@ class BufferTooShort(Exception):
     pass
 
 
-class ZnpMtProtocol(zigpy.serial.SerialProtocol):
+class ZnpMtProtocol(SerialProtocol):
     def __init__(self, api, *, url: str | None = None) -> None:
         super().__init__()
         self._api = api
@@ -74,15 +74,9 @@ class ZnpMtProtocol(zigpy.serial.SerialProtocol):
         LOGGER.log(log.TRACE, "Sending data: %s", Bytes.__repr__(data))
         self._transport.write(data)
 
-    def set_dtr_rts(self, *, dtr: bool, rts: bool) -> None:
-        # TCP transport does not have DTR or RTS pins
-        if not hasattr(self._transport, "serial"):
-            return
-
+    async def set_dtr_rts(self, *, dtr: bool, rts: bool) -> None:
         LOGGER.debug("Setting serial pin states: DTR=%s, RTS=%s", dtr, rts)
-
-        self._transport.serial.dtr = dtr
-        self._transport.serial.rts = rts
+        await self._transport.set_modem_pins(dtr=dtr, rts=rts)
 
     def _extract_frames(self) -> typing.Iterator[frames.TransportFrame]:
         """Extracts frames from the buffer until it is exhausted."""
@@ -145,7 +139,7 @@ class ZnpMtProtocol(zigpy.serial.SerialProtocol):
 async def connect(config: conf.ConfigType, api) -> ZnpMtProtocol:
     port = config[zigpy.config.CONF_DEVICE_PATH]
 
-    _, protocol = await zigpy.serial.create_serial_connection(
+    _, protocol = await create_serial_connection(
         loop=asyncio.get_running_loop(),
         protocol_factory=lambda: ZnpMtProtocol(api, url=port),
         url=port,

--- a/zigpy_znp/zigbee/application.py
+++ b/zigpy_znp/zigbee/application.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-import sys
 import asyncio
 import logging
 
@@ -12,12 +11,6 @@ import zigpy.state
 import zigpy.types
 import zigpy.config
 import zigpy.device
-
-if sys.version_info[:2] < (3, 11):
-    from async_timeout import timeout as asyncio_timeout  # pragma: no cover
-else:
-    from asyncio import timeout as asyncio_timeout  # pragma: no cover
-
 import zigpy.profiles
 import zigpy.zdo.types as zdo_t
 import zigpy.application
@@ -609,7 +602,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
 
         # XXX: If Z-Stack is not compiled with HAL_LED, it will just not respond at all
         try:
-            async with asyncio_timeout(0.5):
+            async with asyncio.timeout(0.5):
                 await self._znp.request(
                     c.UTIL.LEDControl.Req(LED=led, Mode=mode),
                     RspStatus=t.Status.SUCCESS,
@@ -813,7 +806,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             # Broadcasts and ZDO requests will not receive a confirmation
             await self._znp.request(request=request, RspStatus=t.Status.SUCCESS)
         else:
-            async with asyncio_timeout(
+            async with asyncio.timeout(
                 EXTENDED_DATA_CONFIRM_TIMEOUT
                 if extended_timeout
                 else DATA_CONFIRM_TIMEOUT


### PR DESCRIPTION
This migrates zigpy-znp to serialx, since it is one of the few dependencies using transport APIs for interfacing with modem pins. For this, we now use the async-safe `transport.set_modem_pins` interface instead of the `transport.serial.dtr = ...` one.