### PR TITLE
Fix `ZNPCoordinator.request()` rejecting new zigpy kwargs

### DIFF
--- a/zigpy_znp/zigbee/device.py
+++ b/zigpy_znp/zigbee/device.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import logging
 
 import zigpy.zdo
-import zigpy.types
 import zigpy.device
 import zigpy.application
 
@@ -35,32 +34,12 @@ class ZNPCoordinator(zigpy.device.Device):
 
     async def request(
         self,
-        profile,
-        cluster,
-        src_ep,
-        dst_ep,
-        sequence,
-        data,
-        expect_reply=True,
+        *args,
         timeout=2 * zigpy.device.APS_REPLY_TIMEOUT,
-        use_ieee=False,
-        ask_for_ack: bool | None = None,
-        priority: int | None = zigpy.types.PacketPriority.NORMAL,
+        **kwargs,
     ):
         """
-        Normal `zigpy.device.Device:request` except its default timeout is longer.
+        Normal `zigpy.device.Device.request` except its default timeout is longer.
         """
 
-        return await super().request(
-            profile=profile,
-            cluster=cluster,
-            src_ep=src_ep,
-            dst_ep=dst_ep,
-            sequence=sequence,
-            data=data,
-            expect_reply=expect_reply,
-            timeout=timeout,
-            use_ieee=use_ieee,
-            ask_for_ack=ask_for_ack,
-            priority=priority,
-        )
+        return await super().request(*args, timeout=timeout, **kwargs)


### PR DESCRIPTION
zigpy 1.5.0 (https://github.com/zigpy/zigpy/pull/1824) moved request retries into `Device.request`, and `ZDO.request` now forwards `retries`/`retry_delay`. `ZNPCoordinator.request` hardcoded its kwargs and didn't accept them, raising `"TypeError: ZNPCoordinator.request() got an unexpected keyword argument 'retries'"` during coordinator initialization.

Use `*args`/`**kwargs` passthrough so future signature additions don't break the override, keeping only the longer default timeout.

Fixes zigpy/zigpy#1828. Requires https://github.com/zigpy/zigpy-znp/pull/274 and https://github.com/zigpy/zigpy-znp/pull/273 for tests to pass.