### PR TITLE
Retry after route rediscovery on `NWK_NO_ROUTE` in `send_packet`

### DIFF
--- a/tests/application/test_requests.py
+++ b/tests/application/test_requests.py
@@ -592,6 +592,93 @@ async def test_request_recovery_route_rediscovery_af(device, make_application, m
     await app.shutdown()
 
 
+@pytest.mark.parametrize("device", [FormedLaunchpadCC26X2R1])
+async def test_request_recovery_route_rediscovery_then_assoc_failure(
+    device, make_application, mocker
+):
+    # A NWK_NO_ROUTE failure that consumes the first attempt, followed by a
+    # first-time MAC_TRANSACTION_EXPIRED recovery on the final attempt, must surface
+    # as a DeliveryError rather than silently reporting a successful send.
+    app, znp_server = make_application(server_cls=device)
+
+    await app.startup(auto_form=False)
+
+    mocker.patch("zigpy_znp.zigbee.application.DATA_CONFIRM_TIMEOUT", new=0.1)
+    app._znp._config[conf.CONF_ZNP_CONFIG][conf.CONF_ARSP_TIMEOUT] = 1
+
+    device = app.add_initialized_device(ieee=t.EUI64(range(8)), nwk=0xABCD)
+
+    assoc_device, _ = c.util.Device.deserialize(b"\xFF" * 100)
+    assoc_device.shortAddr = device.nwk
+    assoc_device.nodeRelation = c.util.NodeRelation.CHILD_FFD_RX_IDLE
+
+    # First attempt fails with NWK_NO_ROUTE, the retried attempt fails with a
+    # first-time MAC_TRANSACTION_EXPIRED association failure
+    data_confirm_statuses = iter(
+        [t.Status.NWK_NO_ROUTE, t.Status.MAC_TRANSACTION_EXPIRED]
+    )
+
+    def data_confirm_replier(req):
+        return c.AF.DataConfirm.Callback(
+            Status=next(data_confirm_statuses),
+            Endpoint=1,
+            TSN=1,
+        )
+
+    znp_server.reply_to(
+        c.AF.DataRequestExt.Req(partial=True),
+        responses=[
+            c.AF.DataRequestExt.Rsp(Status=t.Status.SUCCESS),
+            data_confirm_replier,
+        ],
+    )
+
+    znp_server.reply_to(
+        c.UTIL.AssocGetWithAddress.Req(IEEE=device.ieee, partial=True),
+        responses=[c.UTIL.AssocGetWithAddress.Rsp(Device=assoc_device)],
+    )
+
+    did_assoc_remove = znp_server.reply_to(
+        c.UTIL.AssocRemove.Req(IEEE=device.ieee),
+        responses=[c.UTIL.AssocRemove.Rsp(Status=t.Status.SUCCESS)],
+    )
+
+    did_assoc_add = znp_server.reply_to(
+        c.UTIL.AssocAdd.Req(
+            NWK=device.nwk,
+            IEEE=device.ieee,
+            NodeRelation=c.util.NodeRelation.CHILD_FFD_RX_IDLE,
+        ),
+        responses=[c.UTIL.AssocAdd.Rsp(Status=t.Status.SUCCESS)],
+    )
+
+    was_route_discovered = znp_server.reply_to(
+        c.ZDO.ExtRouteDisc.Req(
+            Dst=device.nwk, Options=c.zdo.RouteDiscoveryOptions.UNICAST, partial=True
+        ),
+        responses=[c.ZDO.ExtRouteDisc.Rsp(Status=t.Status.SUCCESS)],
+    )
+
+    with pytest.raises(DeliveryError):
+        await app.request(
+            device=device,
+            profile=260,
+            cluster=1,
+            src_ep=1,
+            dst_ep=1,
+            sequence=1,
+            data=b"\x00",
+        )
+
+    # The route was rediscovered after the first failure
+    assert was_route_discovered.call_count >= 1
+    # The association removed on the final attempt must be re-added on failure
+    assert len(did_assoc_remove.mock_calls) >= 1
+    assert len(did_assoc_add.mock_calls) >= 1
+
+    await app.shutdown()
+
+
 @pytest.mark.parametrize("device_cls", FORMED_DEVICES)
 @pytest.mark.parametrize("fw_assoc_remove", [True, False])
 @pytest.mark.parametrize("final_status", [t.Status.SUCCESS, t.Status.APS_NO_ACK])

--- a/tests/application/test_requests.py
+++ b/tests/application/test_requests.py
@@ -670,11 +670,13 @@ async def test_request_recovery_route_rediscovery_then_assoc_failure(
             data=b"\x00",
         )
 
-    # The route was rediscovered after the first failure
-    assert was_route_discovered.call_count >= 1
-    # The association removed on the final attempt must be re-added on failure
-    assert len(did_assoc_remove.mock_calls) >= 1
-    assert len(did_assoc_add.mock_calls) >= 1
+    # Route discovery runs once for the first-attempt NWK_NO_ROUTE and once during
+    # the final-attempt MAC_TRANSACTION_EXPIRED recovery
+    assert was_route_discovered.call_count == 2
+    # The association is removed exactly once during recovery and, since the send
+    # ultimately fails, must be re-added exactly once
+    assert len(did_assoc_remove.mock_calls) == 1
+    assert len(did_assoc_add.mock_calls) == 1
 
     await app.shutdown()
 

--- a/zigpy_znp/zigbee/application.py
+++ b/zigpy_znp/zigbee/application.py
@@ -978,9 +978,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
                                 continue
 
                         # Perform route discovery explicitly if the stack fails and
-                        # then retry the request. zigpy no longer retries failed
-                        # requests at the application level (zigpy #1824), so the retry
-                        # must happen here for route rediscovery to take effect.
+                        # then retry the request
                         if (
                             e.response.Status == t.Status.NWK_NO_ROUTE
                             and device is not None

--- a/zigpy_znp/zigbee/application.py
+++ b/zigpy_znp/zigbee/application.py
@@ -891,8 +891,9 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         try:
             # We retry sending twice but the only devices that will use the second retry
             # attempt are sleeping end devices that silently switched parents from the
-            # coordinator, all others will fail immediately
-            for _retry_attempt in range(2):
+            # coordinator, as well as devices for which we just rediscovered a route.
+            # All others will fail immediately.
+            for retry_attempt in range(2):
                 async with self._limit_concurrency(priority=packet.priority):
                     try:
                         # ZDO requests do not generate `AF.DataConfirm` messages
@@ -973,9 +974,17 @@ class ControllerApplication(zigpy.application.ControllerApplication):
                             else:
                                 continue
 
-                        # Perform route discovery explicitly if the stack fails
-                        if e.response.Status == t.Status.NWK_NO_ROUTE:
+                        # Perform route discovery explicitly if the stack fails and
+                        # then retry the request. zigpy no longer retries failed
+                        # requests at the application level (zigpy #1824), so the retry
+                        # must happen here for route rediscovery to take effect.
+                        if (
+                            e.response.Status == t.Status.NWK_NO_ROUTE
+                            and device is not None
+                            and retry_attempt < 1
+                        ):
                             await self._discover_route(device.nwk)
+                            continue
 
                         raise
         except InvalidCommandResponse as e:

--- a/zigpy_znp/zigbee/application.py
+++ b/zigpy_znp/zigbee/application.py
@@ -887,6 +887,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         succeeded = False
         child_association = None
         tried_assoc_remove = False
+        last_error = None
 
         try:
             # We retry sending twice but the only devices that will use the second retry
@@ -934,6 +935,8 @@ class ControllerApplication(zigpy.application.ControllerApplication):
                         succeeded = True
                         break
                     except InvalidCommandResponse as e:
+                        last_error = e
+
                         # Child aging is disabled so if a child switches parents from
                         # the coordinator to another router, we will not be able to
                         # re-discover a route to it. We have to manually drop the child
@@ -987,6 +990,13 @@ class ControllerApplication(zigpy.application.ControllerApplication):
                             continue
 
                         raise
+            else:
+                # Every attempt was consumed by a recovery `continue` without a
+                # successful send (e.g. NWK_NO_ROUTE followed by a first-time
+                # MAC_TRANSACTION_EXPIRED on the final attempt). Surface the last
+                # error instead of silently reporting the send as successful.
+                if last_error is not None:
+                    raise last_error
         except InvalidCommandResponse as e:
             status = e.response.Status
             raise DeliveryError(f"Failed to send request: {status!r}", status=status)


### PR DESCRIPTION
When a request fails with `NWK_NO_ROUTE`, `send_packet` rediscovered the route but then re-raised, relying on zigpy's application-level retry loop to actually re-send. zigpy 1.5.0 (https://github.com/zigpy/zigpy/pull/1824) moved retries out of `ControllerApplication.request`, so a directly-issued request was no longer retried and route rediscovery never took effect.

Retry the send once within `send_packet`'s existing recovery loop after rediscovering the route, matching the `MAC_TRANSACTION_EXPIRED` recovery path which already does this. This makes `send_packet` self-recovering regardless of caller.

The new `NWK_NO_ROUTE` retry path could combine with the existing `MAC_TRANSACTION_EXPIRED` recovery to consume both send attempts via `continue` without ever raising: a first-attempt `NWK_NO_ROUTE` followed by a first-time `MAC_TRANSACTION_EXPIRED` on the final attempt left the loop with `succeeded=False` and no exception, so an undelivered packet was reported as a successful send. The second commit adds a `for`/`else` safety net that re-raises the last error whenever the recovery loop completes without a successful send, along with a regression test for that fall-through (thanks to the Copilot review for catching this).

Requires https://github.com/zigpy/zigpy-znp/pull/272 and https://github.com/zigpy/zigpy-znp/pull/274 for tests to pass.

<details>
<summary>Behavioral analysis: how the two recovery paths interact across versions</summary>

`send_packet`'s recovery loop is `for retry_attempt in range(2)` — a **2-attempt budget**. The real change is *who consumes that budget*:

| | `MAC_TRANSACTION_EXPIRED` path | `NWK_NO_ROUTE` path |
|---|---|---|
| **Before this PR** | `_discover_route` + `continue` (consumes an attempt) | `_discover_route` + **`raise`** (consumes 0 internal attempts; relied on zigpy's app-level retry loop to re-run `send_packet`) |
| **Now** | same `continue` | `_discover_route` + **`continue`** (now also consumes an attempt), guarded to `retry_attempt < 1` |

Before the PR, only MAC recovery used the internal budget; NWK recovery bailed out and leaned on zigpy's *external* `ControllerApplication.request` retry loop (default 3 attempts). zigpy 1.5.0 deleted that external loop, so both recovery paths now share the single 2-attempt internal budget.

**Empirical results (post-PR), for the two cross-order cases:**

```
MAC → NWK : raises DeliveryError(NWK_NO_ROUTE)            route_disc=1  assoc_remove=1  assoc_add=1
NWK → MAC : raises DeliveryError(MAC_TRANSACTION_EXPIRED) route_disc=2  assoc_remove=1  assoc_add=1
```

- **MAC then NWK** — attempt 0 runs full MAC recovery (assoc remove + route discovery + `continue`); attempt 1 hits `NWK_NO_ROUTE` but is the *final* attempt, so the `retry_attempt < 1` guard suppresses route rediscovery and it raises. Correct `DeliveryError`; association re-added.
- **NWK then MAC** — attempt 0 rediscovers route + `continue`; attempt 1 runs full MAC recovery + `continue`; loop exhausts → `for`/`else` raises. Correct `DeliveryError`; association re-added. (This is the case that silently succeeded before the safety net.)

Both orderings terminate correctly and the association table stays balanced (`remove == add`).

**Genuine differences vs. before the PR (all benign):**

1. `NWK_NO_ROUTE` on the *final* internal attempt no longer triggers route rediscovery (the `retry_attempt < 1` guard). Negligible — route discovery only helps a subsequent send, and the next `Device.request`-level retry re-enters `send_packet` at attempt 0 and rediscovers anyway.
2. MAC and NWK recovery now compete for the same 2 attempts; a mixed sequence exhausts the budget after two errors and raises.
3. `NWK → MAC` now does an assoc-remove/re-add inside a call that can't retry afterward (slightly wasteful churn). Harmless — the re-add happens in `finally`, so the table stays consistent.

**Real traffic is not worse off:** normal unicast goes through `Device.request`, which in zigpy 1.5.x still retries (3 attempts), each invoking `send_packet`'s 2-attempt loop — so total send attempts are higher, not lower, and a pure `NWK_NO_ROUTE` now self-recovers within a single `send_packet` call. Pure `MAC_TRANSACTION_EXPIRED` recovery is unchanged. The only callers without the external retry are direct `app.request` users (broadcasts, some internal flows), which generally don't carry a single target device/association and so don't hit this recovery.

</details>
