### PR TITLE
Remove obsolete retrying patch from tests

### DIFF
--- a/tests/application/test_joining.py
+++ b/tests/application/test_joining.py
@@ -5,7 +5,6 @@ from unittest import mock
 import pytest
 import zigpy.util
 import zigpy.types
-import zigpy.device
 import zigpy.zdo.types as zdo_t
 
 import zigpy_znp.types as t
@@ -184,10 +183,6 @@ async def test_permit_join_with_key(device, permit_result, make_application, moc
     await app.shutdown()
 
 
-@mock.patch(
-    "zigpy.device.Device._initialize",
-    new=zigpy.device.Device._initialize.__wrapped__,  # to disable retries
-)
 @pytest.mark.parametrize("device", FORMED_DEVICES)
 async def test_on_zdo_device_join(device, make_application, mocker):
     app, znp_server = make_application(server_cls=device)
@@ -210,10 +205,6 @@ async def test_on_zdo_device_join(device, make_application, mocker):
     await app.shutdown()
 
 
-@mock.patch(
-    "zigpy.device.Device._initialize",
-    new=zigpy.device.Device._initialize.__wrapped__,  # to disable retries
-)
 @pytest.mark.parametrize("device", FORMED_DEVICES)
 async def test_on_zdo_device_join_and_announce_fast(device, make_application, mocker):
     app, znp_server = make_application(server_cls=device)
@@ -273,10 +264,6 @@ async def test_on_zdo_device_join_and_announce_fast(device, make_application, mo
 
 
 @mock.patch("zigpy_znp.zigbee.application.DEVICE_JOIN_MAX_DELAY", new=0.1)
-@mock.patch(
-    "zigpy.device.Device._initialize",
-    new=zigpy.device.Device._initialize.__wrapped__,  # to disable retries
-)
 @pytest.mark.parametrize("device", FORMED_DEVICES)
 async def test_on_zdo_device_join_and_announce_slow(device, make_application, mocker):
     app, znp_server = make_application(server_cls=device)


### PR DESCRIPTION
`Device._initialize` is no longer wrapped with a retry decorator in zigpy 1.5.0, so `Device._initialize.__wrapped__` raises AttributeError at collection time. The `@mock.patch(..., new=...__wrapped__)` only existed to strip those retries, which no longer exist, so drop it from the three join/announce tests (and the now-unused zigpy.device import).

Requires https://github.com/zigpy/zigpy-znp/pull/273 for tests to pass.