### PR TITLE
Bump zigpy to 1.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 license = {text = "GPL-3.0"}
 requires-python = ">=3.11"
 dependencies = [
-    "zigpy>=1.3.0",
+    "zigpy>=1.5.0",
     "voluptuous",
     "coloredlogs",
     "jsonschema",


### PR DESCRIPTION
We've had multiple recent PRs that target zigpy 1.5.x compatibility. The fixes themselves still work on older versions, but the adjusted tests do not. Before releasing v1.1.0, we bump the zigpy requirement to 1.5.0, since that's what this zigpy-znp version now mainly targets.

Recent PRs:
- https://github.com/zigpy/zigpy-znp/pull/272
- https://github.com/zigpy/zigpy-znp/pull/273
- https://github.com/zigpy/zigpy-znp/pull/274