### PR TITLE
Fix `MgmtRtgRsp.Routes` not being marked as optional

### DIFF
--- a/zigpy_znp/commands/zdo.py
+++ b/zigpy_znp/commands/zdo.py
@@ -1194,7 +1194,7 @@ class ZDO(t.CommandsBase, subsystem=t.Subsystem.ZDO):
             t.Param(
                 "Status", t.ZDOStatus, "Status is either Success (0) or Failure (1)"
             ),
-            t.Param("Routes", zigpy.zdo.types.Routes, "Routes"),
+            t.Param("Routes", zigpy.zdo.types.Routes, "Routes", optional=True),
         ),
     )
 


### PR DESCRIPTION
Closes #278

## Summary

`ZDO.MgmtRtgRsp`'s response schema (`zigpy_znp/commands/zdo.py`) declares its `Routes` parameter as required. Per the Zigbee spec, a device that returns `Status: NOT_SUPPORTED` for a routing table request legitimately omits the routes list — the frame is genuinely shorter, not corrupted or malformed.

Because `Routes` isn't marked optional, `CommandBase.from_frame()` (`zigpy_znp/types/commands.py`) runs out of data while trying to deserialize it, hits the "out of data but required" branch, and raises:

\`\`\`
ValueError: Frame data is truncated (parsed {...}), required parameter remains: Param(name='Routes', ...)
\`\`\`

This exception is unhandled at the point frames are processed, which halts processing of whatever comes next on the wire — meaning a single `NOT_SUPPORTED` response from any router on the mesh can silently drop check-ins from unrelated devices queued behind it. In my case this manifested as sleepy Zigbee end-devices (battery sensors) going unavailable with zero errors logged under their own address — the actual failure was upstream, triggered by a completely different device's routing response. Full details and log excerpts are in #278.

## Fix

One-line change: mark `Routes` optional on `MgmtRtgRsp`, exactly as `Neighbors` is already marked optional two command definitions earlier in the same file:

\`\`\`python
# Before
t.Param("Routes", zigpy.zdo.types.Routes, "Routes"),

# After
t.Param("Routes", zigpy.zdo.types.Routes, "Routes", optional=True),
\`\`\`

`from_frame()`'s existing optional-handling logic already does the right thing once this flag is set — it cleanly stops parsing and returns `Routes=None` instead of raising.

This also brings zigpy-znp's TI Z-Stack-specific schema in line with upstream `zigpy`'s own generic ZDO schema, which already treats this field as optional:

\`\`\`python
# zigpy/zdo/types.py
ZDOCmd.Mgmt_Rtg_rsp: (STATUS, ("Routes", t.Optional(Routes))),
\`\`\`

## Testing

Reproduced the crash against production logs (`Status.NOT_SUPPORTED` responses from two different routers on my mesh, both triggering the exact `ValueError` above — see #278). Applied this exact change as a runtime patch against a live Home Assistant / zigpy-znp instance and confirmed the schema now correctly reports `Routes` as `optional=True` with no regressions to normal (non-`NOT_SUPPORTED`) `MgmtRtgRsp` parsing.

## Related

Sleepy end-devices affected by the resulting dropped check-ins do not self-heal and require a manual re-pair — this fix should eliminate that class of failure at the source rather than requiring the workaround.