### PR TITLE
Fix `MgmtRtgRsp.Routes` not being marked as optional

### DIFF
--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -559,3 +559,19 @@ def test_neighbors_missing_payload():
         Src=0x821F,
         Status=t.ZDOStatus.NOT_SUPPORTED,
     )
+
+
+def test_routes_missing_payload():
+    frame = frames.GeneralFrame(
+        header=t.CommandHeader(
+            id=0xB2,
+            subsystem=t.Subsystem.ZDO,
+            type=t.CommandType.AREQ,
+        ),
+        data=b"\x85\xCC\x84",
+    )
+
+    assert c.ZDO.MgmtRtgRsp.Callback.from_frame(frame) == c.ZDO.MgmtRtgRsp.Callback(
+        Src=0xCC85,
+        Status=t.ZDOStatus.NOT_SUPPORTED,
+    )

--- a/zigpy_znp/commands/zdo.py
+++ b/zigpy_znp/commands/zdo.py
@@ -1194,7 +1194,7 @@ class ZDO(t.CommandsBase, subsystem=t.Subsystem.ZDO):
             t.Param(
                 "Status", t.ZDOStatus, "Status is either Success (0) or Failure (1)"
             ),
-            t.Param("Routes", zigpy.zdo.types.Routes, "Routes"),
+            t.Param("Routes", zigpy.zdo.types.Routes, "Routes", optional=True),
         ),
     )
 


### PR DESCRIPTION
## Background

I run zigpy-znp, and every routing-table scan (`Mgmt_Rtg_req` to each router) leaves a handful of `ERROR` lines with full tracebacks in my log, one per router whose firmware doesn't implement the request. Looking for the cause I found #278 and #279 by @fdelacou: the same traceback, the same root cause, and a correct one-line fix.

#279 has been open since 2026-08-10. The review on it agreed with the fix and asked for a regression test in the shape of #228, and there has been no activity since. I couldn't push to that branch, so this PR carries fdelacou's commit unchanged (their authorship is preserved) and adds the requested test on top, so there is something merge-ready. If fdelacou would rather update #279 instead, I'm happy to close this one.

Supersedes #279. Refs #278 (left open on purpose: the device-drop symptoms reported there most likely have a separate cause, see Impact below).

## The bug

`ZDO.MgmtRtgRsp` in `zigpy_znp/commands/zdo.py` declares its `Routes` parameter as required. Per the ZDO spec, `Mgmt_Rtg_rsp` only carries the routing table when `Status == SUCCESS`; a device answering with `NOT_SUPPORTED` legitimately ends the frame after the status byte. `CommandBase.from_frame()` then runs out of data on a required parameter and raises:

```
ValueError: Frame data is truncated (parsed {'Src': 0xCC85, 'Status': <Status.NOT_SUPPORTED: 132>}), required parameter remains: Param(name='Routes', ...)
```

## The fix

Mark the parameter `optional=True`. This is exactly what #228 did for `MgmtLqiRsp.Neighbors`, the sibling command with the identical failure a few lines up in the same file, and it matches zigpy's own ZDO schema, which already has `ZDOCmd.Mgmt_Rtg_rsp: (STATUS, ("Routes", t.Optional(Routes)))`.

## Impact

#278 and the original #279 description suggested the exception could stall frame processing and drop check-ins from other devices. It can't: in `zigpy_znp/uart.py` the `try`/`except` sits inside the per-frame loop, so the failure is contained to the one offending frame. Nothing in zigpy-znp reads `MgmtRtgRsp.Callback.Routes` either, so `Routes=None` propagates nowhere.

What this fixes is the spurious `ERROR` plus traceback logged for every non-`SUCCESS` routing-table response, which on a network with routers that don't implement the request means a burst of them on every scan. Those log lines send people chasing unrelated device drops, as happened in #278. The sleepy-device symptoms described there most likely have another cause, which is why this doesn't close #278.

## Test

`test_routes_missing_payload` in `tests/test_commands.py`, placed right after `test_neighbors_missing_payload` and written in the same shape, using the frame logged in #278. It fails on `dev` with the error above and passes with the fix. The full suite passes (391 tests).
